### PR TITLE
Remove some unused code

### DIFF
--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -41,12 +41,6 @@ void fromString(const std::string &str, T &out, bool &ok) {
   ok = !in.fail();
 }
 
-template <>
-void fromString(const std::string &str, std::string &out, bool &ok) {
-  ok = true;
-  out = str;
-}
-
 // Returns false only on invalid format, not on missing key
 template <typename T, typename Validator>
 bool loadParam(const std::map<std::string, std::string> &map,

--- a/src/detail/Testing.cpp
+++ b/src/detail/Testing.cpp
@@ -37,7 +37,6 @@ SearchResult searchProperty(const Property &property,
   const auto maxDiscard = params.maxDiscardRatio * params.maxSuccess;
 
   auto recentDiscards = 0;
-  auto random = Random(params.seed);
 
   while (searchResult.numSuccess < params.maxSuccess) {
     const auto size =

--- a/src/detail/Utility.cpp
+++ b/src/detail/Utility.cpp
@@ -9,7 +9,6 @@ namespace detail {
 std::string demangle(const char *name) {
   std::string demangled(name);
   int status;
-  std::size_t length;
   char *buf = abi::__cxa_demangle(name, 0, 0, &status);
   if (status == 0) {
     demangled = std::string(buf);


### PR DESCRIPTION
It causes errors when I try to compile the library.

I'm trying to pick up the GC stuff I worked on before, and I have more or less given up the idea of writing GC'd code in C++ for testing. In order to support copying garbage collectors, the test programs must be written so that on every GC safepoint (in my simple case allocations) there must be no raw pointers to objects (for example this or by-ref params), and that just doesn't work out. So I'm going to try to generate mutator programs and use the stateful testing capabilities of RapidCheck instead. Curious to see how that turns out.