### PR TITLE
Add exception checking macros

### DIFF
--- a/doc/assertions.md
+++ b/doc/assertions.md
@@ -40,6 +40,12 @@ Fails the test case if `expression` evaluates to `false`.
 ### `RC_ASSERT_FALSE(expression)` ###
 Fails the test case if `expression` evaluates to `true`. Use this instead of `RC_ASSERT(!(...))` since RapidCheck cannot capture the expression in that case.
 
+### `RC_ASSERT_THROWS(expression)` ###
+Fails the test case if `expression` does not throw an exception.
+
+### `RC_ASSERT_THROWS_AS(expression, ExceptionType)` ###
+Fails the test case if `expression` does not throw an exception that matches `ExceptionType`.
+
 ### `RC_FAIL(msg)` ###
 Unconditionally fails the test case with `msg` as message.
 

--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -12,12 +12,14 @@
            __LINE__,                                                           \
            name "(" #expression ")")
 
-#define RC_INTERNAL_UNCONDITIONAL_RESULT(ResultType, name, msg)                \
+#define RC_INTERNAL_STRINGIFY(x) #x
+
+#define RC_INTERNAL_UNCONDITIONAL_RESULT(ResultType, name, expression)         \
   do {                                                                         \
     throw ::rc::detail::CaseResult(                                            \
         ::rc::detail::CaseResult::Type::ResultType,                            \
         ::rc::detail::makeMessage(                                             \
-            __FILE__, __LINE__, name "(" #msg ")", (msg)));                    \
+            __FILE__, __LINE__, name "(" #expression ")", {expression}));      \
   } while (false)
 
 /// Fails the current test case unless the given condition is `true`.
@@ -73,22 +75,23 @@
   } while (false)
 
 /// Unconditionally fails the current test case with the given message.
-#define RC_FAIL(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Failure, "RC_FAIL", msg)
+#define RC_FAIL(...)                                                           \
+  RC_INTERNAL_UNCONDITIONAL_RESULT(Failure, "RC_FAIL", __VA_ARGS__)
 
 /// Succeed if the given condition is true.
 #define RC_SUCCEED_IF(expression)                                              \
   RC_INTERNAL_CONDITIONAL_RESULT(Success, expression, false, "RC_SUCCEED_IF")
 
 /// Unconditionally succeed with the given message.
-#define RC_SUCCEED(msg)                                                        \
-  RC_INTERNAL_UNCONDITIONAL_RESULT(Success, "RC_SUCCEED", msg)
+#define RC_SUCCEED(...)                                                        \
+  RC_INTERNAL_UNCONDITIONAL_RESULT(Success, "RC_SUCCEED", __VA_ARGS__)
 
 /// Discards the current test case if the given condition is false.
 #define RC_PRE(expression)                                                     \
   RC_INTERNAL_CONDITIONAL_RESULT(Discard, expression, true, "RC_PRE", !)
 
 /// Discards the current test case with the given description.
-#define RC_DISCARD(msg)                                                        \
-  RC_INTERNAL_UNCONDITIONAL_RESULT(Discard, "RC_DISCARD", msg)
+#define RC_DISCARD(...)                                                        \
+  RC_INTERNAL_UNCONDITIONAL_RESULT(Discard, "RC_DISCARD", __VA_ARGS__)
 
 #include "Assertions.hpp"

--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -12,7 +12,7 @@
            __LINE__,                                                           \
            name "(" #expression ")")
 
-#define RC__UNCONDITIONAL_RESULT(ResultType, description)                      \
+#define RC_INTERNAL_UNCONDITIONAL_RESULT(ResultType, description)              \
   do {                                                                         \
     throw ::rc::detail::CaseResult(::rc::detail::CaseResult::Type::ResultType, \
                                    ::rc::detail::makeDescriptionMessage(       \
@@ -72,20 +72,20 @@
   } while (false)
 
 /// Unconditionally fails the current test case with the given message.
-#define RC_FAIL(msg) RC__UNCONDITIONAL_RESULT(Failure, (msg))
+#define RC_FAIL(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Failure, (msg))
 
 /// Succeed if the given condition is true.
 #define RC_SUCCEED_IF(expression)                                              \
   RC_INTERNAL_CONDITIONAL_RESULT(Success, expression, false, "RC_SUCCEED_IF")
 
 /// Unconditionally succeed with the given message.
-#define RC_SUCCEED(msg) RC__UNCONDITIONAL_RESULT(Success, (msg))
+#define RC_SUCCEED(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Success, (msg))
 
 /// Discards the current test case if the given condition is false.
 #define RC_PRE(expression)                                                     \
   RC_INTERNAL_CONDITIONAL_RESULT(Discard, expression, true, "RC_PRE", !)
 
 /// Discards the current test case with the given description.
-#define RC_DISCARD(msg) RC__UNCONDITIONAL_RESULT(Discard, (msg))
+#define RC_DISCARD(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Discard, (msg))
 
 #include "Assertions.hpp"

--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -31,6 +31,46 @@
                                  "RC_ASSERT_"                                  \
                                  "FALSE")
 
+/// Fails the current test case unless the provided expression throws an
+/// exception of any type
+#define RC_ASSERT_THROWS(expression)                                           \
+  do {                                                                         \
+    try {                                                                      \
+      expression;                                                              \
+    } catch (...) {                                                            \
+      break;                                                                   \
+    }                                                                          \
+    throw ::rc::detail::CaseResult(                                            \
+        ::rc::detail::CaseResult::Type::Failure,                               \
+        ::rc::detail::makeUnthrownExceptionMessage(                            \
+            __FILE__, __LINE__, "RC_ASSERT_THROWS(" #expression ")"));         \
+  } while (false)
+
+/// Fails the current test case unless the given expression throws an
+/// exception that matches the given exception type
+#define RC_ASSERT_THROWS_AS(expression, ExceptionType)                         \
+  do {                                                                         \
+    try {                                                                      \
+      expression;                                                              \
+    } catch (const ExceptionType &) {                                          \
+      break;                                                                   \
+    } catch (...) {                                                            \
+      throw ::rc::detail::CaseResult(::rc::detail::CaseResult::Type::Failure,  \
+                                     ::rc::detail::makeWrongExceptionMessage(  \
+                                         __FILE__,                             \
+                                         __LINE__,                             \
+                                         "RC_ASSERT_THROWS_AS(" #expression    \
+                                         ", " #ExceptionType ")",              \
+                                         #ExceptionType));                     \
+    }                                                                          \
+    throw ::rc::detail::CaseResult(::rc::detail::CaseResult::Type::Failure,    \
+                                   ::rc::detail::makeUnthrownExceptionMessage( \
+                                       __FILE__,                               \
+                                       __LINE__,                               \
+                                       "RC_ASSERT_THROWS_AS(" #expression      \
+                                       ", " #ExceptionType ")"));              \
+  } while (false)
+
 /// Unconditionally fails the current test case with the given message.
 #define RC_FAIL(msg) RC__UNCONDITIONAL_RESULT(Failure, (msg))
 

--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -12,11 +12,12 @@
            __LINE__,                                                           \
            name "(" #expression ")")
 
-#define RC_INTERNAL_UNCONDITIONAL_RESULT(ResultType, description)              \
+#define RC_INTERNAL_UNCONDITIONAL_RESULT(ResultType, name, msg)                \
   do {                                                                         \
-    throw ::rc::detail::CaseResult(::rc::detail::CaseResult::Type::ResultType, \
-                                   ::rc::detail::makeDescriptionMessage(       \
-                                       __FILE__, __LINE__, (description)));    \
+    throw ::rc::detail::CaseResult(                                            \
+        ::rc::detail::CaseResult::Type::ResultType,                            \
+        ::rc::detail::makeMessage(                                             \
+            __FILE__, __LINE__, name "(" #msg ")", (msg)));                    \
   } while (false)
 
 /// Fails the current test case unless the given condition is `true`.
@@ -72,20 +73,22 @@
   } while (false)
 
 /// Unconditionally fails the current test case with the given message.
-#define RC_FAIL(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Failure, (msg))
+#define RC_FAIL(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Failure, "RC_FAIL", msg)
 
 /// Succeed if the given condition is true.
 #define RC_SUCCEED_IF(expression)                                              \
   RC_INTERNAL_CONDITIONAL_RESULT(Success, expression, false, "RC_SUCCEED_IF")
 
 /// Unconditionally succeed with the given message.
-#define RC_SUCCEED(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Success, (msg))
+#define RC_SUCCEED(msg)                                                        \
+  RC_INTERNAL_UNCONDITIONAL_RESULT(Success, "RC_SUCCEED", msg)
 
 /// Discards the current test case if the given condition is false.
 #define RC_PRE(expression)                                                     \
   RC_INTERNAL_CONDITIONAL_RESULT(Discard, expression, true, "RC_PRE", !)
 
 /// Discards the current test case with the given description.
-#define RC_DISCARD(msg) RC_INTERNAL_UNCONDITIONAL_RESULT(Discard, (msg))
+#define RC_DISCARD(msg)                                                        \
+  RC_INTERNAL_UNCONDITIONAL_RESULT(Discard, "RC_DISCARD", msg)
 
 #include "Assertions.hpp"

--- a/include/rapidcheck/Assertions.hpp
+++ b/include/rapidcheck/Assertions.hpp
@@ -6,7 +6,7 @@ namespace detail {
 std::string makeMessage(const std::string &file,
                         int line,
                         const std::string &assertion,
-                        const std::string &extra);
+                        const std::string &extra = "");
 
 std::string makeExpressionMessage(const std::string &file,
                                   int line,

--- a/include/rapidcheck/Assertions.hpp
+++ b/include/rapidcheck/Assertions.hpp
@@ -12,6 +12,15 @@ std::string makeExpressionMessage(const std::string &file,
                                   const std::string &assertion,
                                   const std::string &expansion);
 
+std::string makeUnthrownExceptionMessage(const std::string &file,
+                                         int line,
+                                         const std::string &assertion);
+
+std::string makeWrongExceptionMessage(const std::string &file,
+                                      int line,
+                                      const std::string &assertion,
+                                      const std::string &expected);
+
 template <typename Expression>
 void doAssert(const Expression &expression,
               bool expectedResult,

--- a/include/rapidcheck/Assertions.hpp
+++ b/include/rapidcheck/Assertions.hpp
@@ -3,9 +3,10 @@
 namespace rc {
 namespace detail {
 
-std::string makeDescriptionMessage(const std::string &file,
-                                   int line,
-                                   const std::string &description);
+std::string makeMessage(const std::string &file,
+                        int line,
+                        const std::string &assertion,
+                        const std::string &extra);
 
 std::string makeExpressionMessage(const std::string &file,
                                   int line,

--- a/src/detail/Assertions.cpp
+++ b/src/detail/Assertions.cpp
@@ -7,10 +7,15 @@ std::string makeMessage(const std::string &file,
                         int line,
                         const std::string &assertion,
                         const std::string &extra) {
-  return file + ":" + std::to_string(line) + ":\n" + assertion +
-      "\n"
-      "\n" +
-      extra;
+  auto msg = file + ":" + std::to_string(line) + ":\n" + assertion;
+  if (!extra.empty()) {
+    msg +=
+        "\n"
+        "\n" +
+        extra;
+  }
+
+  return msg;
 }
 
 std::string makeExpressionMessage(const std::string &file,

--- a/src/detail/Assertions.cpp
+++ b/src/detail/Assertions.cpp
@@ -3,41 +3,37 @@
 namespace rc {
 namespace detail {
 
-std::string makeDescriptionMessage(const std::string &file,
-                                   int line,
-                                   const std::string &description) {
-  return file + ":" + std::to_string(line) + ":\n" + description;
+std::string makeMessage(const std::string &file,
+                        int line,
+                        const std::string &assertion,
+                        const std::string &extra) {
+  return file + ":" + std::to_string(line) + ":\n" + assertion +
+      "\n"
+      "\n" +
+      extra;
 }
 
 std::string makeExpressionMessage(const std::string &file,
                                   int line,
                                   const std::string &assertion,
                                   const std::string &expansion) {
-  return makeDescriptionMessage(file, line, assertion) +
-      "\n"
-      "\n"
-      "Expands to:\n" +
-      expansion;
+  return makeMessage(file, line, assertion, "Expands to:\n" + expansion);
 }
 
 std::string makeUnthrownExceptionMessage(const std::string &file,
                                          int line,
                                          const std::string &assertion) {
-  return makeDescriptionMessage(file, line, assertion) +
-      "\n"
-      "\n"
-      "No exception was thrown.";
+  return makeMessage(file, line, assertion, "No exception was thrown.");
 }
 
 std::string makeWrongExceptionMessage(const std::string &file,
                                       int line,
                                       const std::string &assertion,
                                       const std::string &expected) {
-  return makeDescriptionMessage(file, line, assertion) +
-      "\n"
-      "\n"
-      "Thrown exception did not match " +
-      expected + ".";
+  return makeMessage(file,
+                     line,
+                     assertion,
+                     "Thrown exception did not match " + expected + ".");
 }
 
 } // namespace detail

--- a/src/detail/Assertions.cpp
+++ b/src/detail/Assertions.cpp
@@ -13,11 +13,31 @@ std::string makeExpressionMessage(const std::string &file,
                                   int line,
                                   const std::string &assertion,
                                   const std::string &expansion) {
-  return file + ":" + std::to_string(line) + ":\n" + assertion +
+  return makeDescriptionMessage(file, line, assertion) +
       "\n"
       "\n"
       "Expands to:\n" +
       expansion;
+}
+
+std::string makeUnthrownExceptionMessage(const std::string &file,
+                                         int line,
+                                         const std::string &assertion) {
+  return makeDescriptionMessage(file, line, assertion) +
+      "\n"
+      "\n"
+      "No exception was thrown.";
+}
+
+std::string makeWrongExceptionMessage(const std::string &file,
+                                      int line,
+                                      const std::string &assertion,
+                                      const std::string &expected) {
+  return makeDescriptionMessage(file, line, assertion) +
+      "\n"
+      "\n"
+      "Thrown exception did not match " +
+      expected + ".";
 }
 
 } // namespace detail

--- a/test/AssertionsTests.cpp
+++ b/test/AssertionsTests.cpp
@@ -18,15 +18,20 @@ bool descriptionContains(const CaseResult &result, const std::string &substr) {
 
 } // namespace
 
-TEST_CASE("makeDescriptionMessage") {
-  SECTION("message contains description") {
-    REQUIRE(stringContains(makeDescriptionMessage("", 0, "foo bar baz"),
-                           "foo bar baz"));
+TEST_CASE("makeMessage") {
+  SECTION("message contains assertion") {
+    REQUIRE(stringContains(makeMessage("", 0, "ASSERT_IT(foo)", ""),
+                           "ASSERT_IT(foo)"));
+  }
+
+  SECTION("message contains extra") {
+    REQUIRE(
+        stringContains(makeMessage("", 0, "", "foo bar baz"), "foo bar baz"));
   }
 
   SECTION("message contains file and line") {
-    REQUIRE(stringContains(makeDescriptionMessage("foo.cpp", 1337, ""),
-                           "foo.cpp:1337"));
+    REQUIRE(
+        stringContains(makeMessage("foo.cpp", 1337, "", ""), "foo.cpp:1337"));
   }
 }
 
@@ -190,7 +195,7 @@ TEST_CASE("assertions") {
         FAIL("Never threw");
       } catch (const CaseResult &result) {
         REQUIRE(result.type == CaseResult::Type::Failure);
-        REQUIRE(descriptionContains(result, "foo bar baz"));
+        REQUIRE(descriptionContains(result, "RC_FAIL(\"foo bar baz\")"));
       }
     }
   }
@@ -219,7 +224,7 @@ TEST_CASE("assertions") {
         FAIL("Never threw");
       } catch (const CaseResult &result) {
         REQUIRE(result.type == CaseResult::Type::Success);
-        REQUIRE(descriptionContains(result, "foo bar baz"));
+        REQUIRE(descriptionContains(result, "RC_SUCCEED(\"foo bar baz\")"));
       }
     }
   }
@@ -246,7 +251,7 @@ TEST_CASE("assertions") {
         FAIL("Never threw");
       } catch (const CaseResult &result) {
         REQUIRE(result.type == CaseResult::Type::Discard);
-        REQUIRE(descriptionContains(result, "foo bar baz"));
+        REQUIRE(descriptionContains(result, "RC_DISCARD(\"foo bar baz\")"));
       }
     }
   }

--- a/test/AssertionsTests.cpp
+++ b/test/AssertionsTests.cpp
@@ -29,6 +29,11 @@ TEST_CASE("makeMessage") {
         stringContains(makeMessage("", 0, "", "foo bar baz"), "foo bar baz"));
   }
 
+  SECTION("message is only two lines if extra is empty") {
+    const auto msg = makeMessage("foo.cpp", 0, "foo", "");
+    REQUIRE(std::count(begin(msg), end(msg), '\n') == 1);
+  }
+
   SECTION("message contains file and line") {
     REQUIRE(
         stringContains(makeMessage("foo.cpp", 1337, "", ""), "foo.cpp:1337"));
@@ -198,6 +203,27 @@ TEST_CASE("assertions") {
         REQUIRE(descriptionContains(result, "RC_FAIL(\"foo bar baz\")"));
       }
     }
+
+    SECTION("throws Failure with macro name only if no message") {
+      try {
+        RC_FAIL();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(result.type == CaseResult::Type::Failure);
+        REQUIRE(descriptionContains(result, "RC_FAIL()"));
+      }
+    }
+
+    SECTION("message is only two lines if no arguments") {
+      try {
+        RC_FAIL();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(std::count(begin(result.description),
+                           end(result.description),
+                           '\n') == 1);
+      }
+    }
   }
 
   SECTION("RC_SUCCEED_IF") {
@@ -227,6 +253,27 @@ TEST_CASE("assertions") {
         REQUIRE(descriptionContains(result, "RC_SUCCEED(\"foo bar baz\")"));
       }
     }
+
+    SECTION("throws Success with macro name only if no message") {
+      try {
+        RC_SUCCEED();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(result.type == CaseResult::Type::Success);
+        REQUIRE(descriptionContains(result, "RC_SUCCEED()"));
+      }
+    }
+
+    SECTION("message is only two lines if no arguments") {
+      try {
+        RC_SUCCEED();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(std::count(begin(result.description),
+                           end(result.description),
+                           '\n') == 1);
+      }
+    }
   }
 
   SECTION("RC_PRE") {
@@ -252,6 +299,27 @@ TEST_CASE("assertions") {
       } catch (const CaseResult &result) {
         REQUIRE(result.type == CaseResult::Type::Discard);
         REQUIRE(descriptionContains(result, "RC_DISCARD(\"foo bar baz\")"));
+      }
+    }
+
+    SECTION("throws Discard with macro name only if no message") {
+      try {
+        RC_DISCARD();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(result.type == CaseResult::Type::Discard);
+        REQUIRE(descriptionContains(result, "RC_DISCARD()"));
+      }
+    }
+
+    SECTION("message is only two lines if no arguments") {
+      try {
+        RC_DISCARD();
+        FAIL("Never threw");
+      } catch (const CaseResult &result) {
+        REQUIRE(std::count(begin(result.description),
+                           end(result.description),
+                           '\n') == 1);
       }
     }
   }

--- a/test/detail/Base64Tests.cpp
+++ b/test/detail/Base64Tests.cpp
@@ -19,13 +19,8 @@ TEST_CASE("base64") {
          const auto size = (n * 4) + 1;
          const auto data =
              *gen::container<std::string>(size, gen::arbitrary<char>());
-         try {
-           // TODO RC_ASSERT_THROWS
-           base64Decode(data);
-         } catch (const ParseException &) {
-           RC_SUCCEED("Threw ParseException");
-         }
-         RC_FAIL("Never threw");
+
+         RC_ASSERT_THROWS_AS(base64Decode(data), ParseException);
        });
 
   prop("throws error on decode with invalid characters",
@@ -39,12 +34,6 @@ TEST_CASE("base64") {
          const auto pos = *gen::inRange<std::size_t>(0, data.size() + 1);
          data.insert(begin(data) + pos, invalid);
 
-         try {
-           // TODO RC_ASSERT_THROWS
-           base64Decode(data);
-         } catch (const ParseException &) {
-           RC_SUCCEED("Threw ParseException");
-         }
-         RC_FAIL("Never threw");
+         RC_ASSERT_THROWS_AS(base64Decode(data), ParseException);
        });
 }

--- a/test/detail/SerializationTests/CompactIntegers.cpp
+++ b/test/detail/SerializationTests/CompactIntegers.cpp
@@ -55,12 +55,10 @@ struct DeserializeCompactProperties {
                        serializeCompact(value, std::back_inserter(data));
                        data.erase(end(data) - 1);
                        T output;
-                       try {
-                         deserializeCompact(begin(data), end(data), output);
-                       } catch (const SerializationException &) {
-                         RC_SUCCEED("Threw SerializationException");
-                       }
-                       RC_FAIL("Threw wrong or no exception");
+
+                       RC_ASSERT_THROWS_AS(
+                           deserializeCompact(begin(data), end(data), output),
+                           SerializationException);
                      });
   }
 };

--- a/test/detail/SerializationTests/CompactRanges.cpp
+++ b/test/detail/SerializationTests/CompactRanges.cpp
@@ -78,13 +78,10 @@ struct DeserializeCompactRangeProperties {
 
           // Now it should fail
           std::vector<T> output;
-          try {
-            deserializeCompact<T>(
-                begin(data), end(data), std::back_inserter(output));
-          } catch (const SerializationException &) {
-            RC_SUCCEED("Threw SerializationException");
-          }
-          RC_FAIL("Threw wrong or no exception");
+          RC_ASSERT_THROWS_AS(deserializeCompact<T>(begin(data),
+                                                    end(data),
+                                                    std::back_inserter(output)),
+                              SerializationException);
         });
   }
 };

--- a/test/detail/SerializationTests/Misc.cpp
+++ b/test/detail/SerializationTests/Misc.cpp
@@ -20,14 +20,10 @@ TEST_CASE("serialization(std::string)") {
            std::vector<std::uint8_t> data;
            serialize(str, std::back_inserter(data));
            data.erase(end(data) - 1);
+
            std::string output;
-           try {
-             // TODO RC_ASSERT_THROWS_AS
-             deserialize(begin(data), end(data), output);
-           } catch (const SerializationException &) {
-             RC_SUCCEED("Threw SerializationException");
-           }
-           RC_FAIL("Threw incorrect or not exception");
+           RC_ASSERT_THROWS_AS(deserialize(begin(data), end(data), output),
+                               SerializationException);
          });
   }
 }

--- a/test/gen/ContainerTests/Fixed.cpp
+++ b/test/gen/ContainerTests/Fixed.cpp
@@ -104,15 +104,7 @@ TEST_CASE("gen::container(std::size_t)") {
          const auto gen =
              gen::container<std::array<int, 3>>(count, gen::arbitrary<int>());
          const auto shrinkable = gen(params.random, params.size);
-         try {
-           shrinkable.value();
-         } catch (const GenerationFailure &) {
-           RC_SUCCEED("Threw GenerationFailure");
-         } catch (const std::exception &e) {
-           std::cout << e.what() << std::endl;
-           RC_FAIL("Threw other exception");
-         }
-         RC_FAIL("Did not throw GenerationFailure");
+         RC_ASSERT_THROWS_AS(shrinkable.value(), GenerationFailure);
        });
 
   // TODO shrink tests?

--- a/test/gen/NumericTests.cpp
+++ b/test/gen/NumericTests.cpp
@@ -214,13 +214,8 @@ struct InRangeProperties {
                        const auto gen =
                            gen::inRange<T>(std::max(a, b), std::min(a, b));
                        const auto shrinkable = gen(params.random, params.size);
-                       try {
-                         shrinkable.value();
-                       } catch (const GenerationFailure &) {
-                         // TODO RC_ASSERT_THROWS
-                         RC_SUCCEED("Threw GenerationFailure");
-                       }
-                       RC_FAIL("Did not throw GenerationFailure");
+                       RC_ASSERT_THROWS_AS(shrinkable.value(),
+                                           GenerationFailure);
                      });
 
     templatedProp<T>("first shrink is min",

--- a/test/gen/PredicateTests.cpp
+++ b/test/gen/PredicateTests.cpp
@@ -39,12 +39,7 @@ TEST_CASE("gen::suchThat") {
        [](const GenParams &params) {
          const auto gen = gen::suchThat(gen::just<int>(0), fn::constant(false));
          const auto shrinkable = gen(params.random, params.size);
-         try {
-           shrinkable.value();
-         } catch (const GenerationFailure &) {
-           RC_SUCCEED("Threw GenerationFailure");
-         }
-         RC_FAIL("Didn't throw GenerationFailure");
+         RC_ASSERT_THROWS_AS(shrinkable.value(), GenerationFailure);
        });
 
   prop("passes the passed size to the underlying generator on the first try",

--- a/test/gen/detail/ExecRawTests.cpp
+++ b/test/gen/detail/ExecRawTests.cpp
@@ -234,12 +234,6 @@ TEST_CASE("execRaw") {
            });
          });
          const auto shrinkable = gen(params.random, params.size);
-         // TODO RC_ASSERT_THROWS
-         try {
-           shrinkable.value();
-         } catch (...) {
-           RC_SUCCEED("Threw exception");
-         }
-         RC_FAIL("Did not throw exception");
+         RC_ASSERT_THROWS(shrinkable.value());
        });
 }

--- a/test/util/Serialization.h
+++ b/test/util/Serialization.h
@@ -44,13 +44,9 @@ struct SerializationProperties {
                      [] {
                        std::vector<std::uint8_t> data;
                        T output;
-                       try {
-                         // TODO RC_ASSERT_THROWS
-                         deserialize(begin(data), end(data), output);
-                       } catch (const SerializationException &) {
-                         RC_SUCCEED("Threw SerializationException");
-                       }
-                       RC_FAIL("Threw wrong or no exception");
+                       RC_ASSERT_THROWS_AS(
+                           deserialize(begin(data), end(data), output),
+                           SerializationException);
                      });
   }
 };


### PR DESCRIPTION
Took the naming convention (THROWS and THROWS_AS) from Catch.