### PR TITLE
Generator for creating command sequences of scaled length

### DIFF
--- a/include/rapidcheck/state.h
+++ b/include/rapidcheck/state.h
@@ -6,4 +6,5 @@
 #include "rapidcheck/state/Commands.h"
 #include "rapidcheck/state/State.h"
 #include "rapidcheck/state/gen/Commands.h"
+#include "rapidcheck/state/gen/CommandsScaledLength.h"
 #include "rapidcheck/state/gen/ExecCommands.h"

--- a/include/rapidcheck/state/gen/CommandsScaledLength.h
+++ b/include/rapidcheck/state/gen/CommandsScaledLength.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "rapidcheck/state/Commands.h"
+
+namespace rc {
+namespace state {
+namespace gen {
+
+/// Generates a valid commands sequence for the given state initial state
+/// consisting of commands of the given type.
+/// Uses the scaling factor to scale the length of the command sequence
+/// by the provided value
+template <typename Cmd, typename GenerationFunc>
+Gen<Commands<Cmd>> commandsScaledLength(const typename Cmd::Model &initialState,
+                                        double scale, GenerationFunc &&genFunc);
+
+}  // namespace gen
+}  // namespace state
+}  // namespace rc
+
+#include "CommandsScaledLength.hpp"

--- a/include/rapidcheck/state/gen/CommandsScaledLength.hpp
+++ b/include/rapidcheck/state/gen/CommandsScaledLength.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "rapidcheck/state/Commands.h"
+
+namespace rc {
+namespace state {
+namespace gen {
+
+template <typename Cmd, typename GenerationFunc>
+Gen<Commands<Cmd>> commandsScaledLength(const typename Cmd::Model &initialState,
+                                        double scale,
+                                        GenerationFunc &&genFunc) {
+
+  /// Generate a sequence of commands where the commands themself
+  /// get passed the size ``size``.
+  auto commands_with_size = [=](int size) {
+    return commands<Cmd>(initialState, [=](const typename Cmd::Model &state) {
+      return rc::gen::resize(size, genFunc(state));
+    });
+  };
+
+  return rc::gen::withSize([=](int size) {
+    return rc::gen::scale(scale, commands_with_size(size));
+  });
+}
+
+} // namespace gen
+} // namespace state
+} // namespace rc


### PR DESCRIPTION
Added a generator based on ``rc::state::gen::commands`` for generating
command sequences with a shorter or longer length than default. The
size parameter of the commands themselves is left unaltered.

Implements the mechanism discussed in #110. I am happy to implement tests or document the feature as well, just let me know if you agree with the interface.
