### PR TITLE
Fix warnings about unused parameters.

### DIFF
--- a/include/rapidcheck/Show.hpp
+++ b/include/rapidcheck/Show.hpp
@@ -191,7 +191,7 @@ template <typename T,
           bool = HasShowValue<T>::value,
           bool = IsStreamInsertible<T>::value>
 struct ShowDefault {
-  static void show(const T &value, std::ostream &os) { os << "<\?\?\?>"; }
+  static void show(const T &/*value*/, std::ostream &os) { os << "<\?\?\?>"; }
 };
 
 template <typename T, bool X>

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -32,7 +32,7 @@ T BitStream<Source>::next(int nbits) {
 
 template <typename Source>
 template <typename T>
-T BitStream<Source>::next(int nbits, std::true_type) {
+T BitStream<Source>::next(int /*nbits*/, std::true_type) {
   return next<unsigned int>(1) != 0;
 }
 

--- a/include/rapidcheck/detail/ShowType.hpp
+++ b/include/rapidcheck/detail/ShowType.hpp
@@ -22,7 +22,7 @@ struct ShowMultipleTypes;
 
 template <>
 struct ShowMultipleTypes<> {
-  static void showType(std::ostream &os) {}
+  static void showType(std::ostream &/*os*/) {}
 };
 
 template <typename Type>

--- a/include/rapidcheck/detail/TestListenerAdapter.h
+++ b/include/rapidcheck/detail/TestListenerAdapter.h
@@ -8,9 +8,9 @@ namespace detail {
 /// `TestListener` that has no-op default implementations of all methods.
 class TestListenerAdapter : public TestListener {
 public:
-  void onTestCaseFinished(const CaseDescription &description) {}
-  void onShrinkTried(const CaseDescription &shrink, bool accepted) {}
-  void onTestFinished(const TestMetadata &metadata, const TestResult &result) {}
+  void onTestCaseFinished(const CaseDescription &/*description*/) {}
+  void onShrinkTried(const CaseDescription &/*shrink*/, bool /*accepted*/) {}
+  void onTestFinished(const TestMetadata &/*metadata*/, const TestResult &/*result*/) {}
 };
 
 } // namespace detail

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -42,7 +42,7 @@ void pushBackAll(Collection &collection, Item &&item, Items &&... items) {
 }
 
 /// Base case for `join`.
-inline std::string join(const std::string &sep, const std::string str) {
+inline std::string join(const std::string &/*sep*/, const std::string str) {
   return str;
 }
 

--- a/include/rapidcheck/fn/Common.hpp
+++ b/include/rapidcheck/fn/Common.hpp
@@ -13,7 +13,7 @@ public:
       : m_value(std::forward<Arg>(arg)) {}
 
   template <typename... Args>
-  T operator()(Args &&... args) const {
+  T operator()(Args &&... /*args*/) const {
     return m_value;
   }
 

--- a/include/rapidcheck/gen/Tuple.hpp
+++ b/include/rapidcheck/gen/Tuple.hpp
@@ -112,7 +112,7 @@ private:
 template <>
 class TupleGen<rc::detail::IndexSequence<>> {
 public:
-  Shrinkable<std::tuple<>> operator()(const Random &random, int size) const {
+  Shrinkable<std::tuple<>> operator()(const Random &/*random*/, int /*size*/) const {
     return shrinkable::just(std::tuple<>());
   }
 };

--- a/src/detail/LogTestListener.cpp
+++ b/src/detail/LogTestListener.cpp
@@ -31,7 +31,7 @@ void LogTestListener::onTestCaseFinished(const CaseDescription &description) {
   }
 }
 
-void LogTestListener::onShrinkTried(const CaseDescription &shrink,
+void LogTestListener::onShrinkTried(const CaseDescription &/*shrink*/,
                                     bool accepted) {
   if (!m_verboseShrinking) {
     return;
@@ -44,8 +44,8 @@ void LogTestListener::onShrinkTried(const CaseDescription &shrink,
   }
 }
 
-void LogTestListener::onTestFinished(const TestMetadata &metadata,
-                                     const TestResult &result) {
+void LogTestListener::onTestFinished(const TestMetadata &/*metadata*/,
+                                     const TestResult &/*result*/) {
   if (m_verboseShrinking || m_verboseProgress) {
     m_out << std::endl;
   }

--- a/src/detail/PropertyContext.cpp
+++ b/src/detail/PropertyContext.cpp
@@ -7,9 +7,9 @@ namespace {
 
 class DummyPropertyContext : public PropertyContext {
 public:
-  bool reportResult(const CaseResult &result) override { return false; }
+  bool reportResult(const CaseResult &/*result*/) override { return false; }
   std::ostream &logStream() override { return std::cerr; }
-  void addTag(std::string str) override {}
+  void addTag(std::string /*str*/) override {}
 };
 
 } // namespace

--- a/src/gen/Numeric.cpp
+++ b/src/gen/Numeric.cpp
@@ -24,7 +24,7 @@ integral<unsigned long long>(const Random &random, int size);
 template Shrinkable<float> real<float>(const Random &random, int size);
 template Shrinkable<double> real<double>(const Random &random, int size);
 
-Shrinkable<bool> boolean(const Random &random, int size) {
+Shrinkable<bool> boolean(const Random &random, int /*size*/) {
   return shrinkable::shrinkRecur(rc::detail::bitStreamOf(random).next<bool>(),
                                  &shrink::boolean);
 }

--- a/src/gen/detail/GenerationHandler.cpp
+++ b/src/gen/detail/GenerationHandler.cpp
@@ -12,7 +12,7 @@ using Any = rc::detail::Any;
 
 /// Default handler. Just throws exception.
 class NullGenerationHandler : public GenerationHandler {
-  Any onGenerate(const Gen<rc::detail::Any> &gen) override {
+  Any onGenerate(const Gen<rc::detail::Any> &/*gen*/) override {
     throw std::runtime_error("operator* is not allowed in this context");
   }
 };


### PR DESCRIPTION
Very trivial changes to silence gcc warnings about unused parameters.