### PR TITLE
Avoid undefined behavior

### DIFF
--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -40,7 +40,6 @@ template <typename Source>
 template <typename T>
 T BitStream<Source>::next(int nbits, std::false_type) {
   using SourceType = decltype(m_source.next());
-  SourceType sourceTypeLength = (sizeof(SourceType) * 8);
 
   if (nbits == 0) {
     return 0;
@@ -61,7 +60,7 @@ T BitStream<Source>::next(int nbits, std::false_type) {
     // To avoid right-shifting data beyond the width of the given type (which is
     // undefined behavior, because of course it is) only perform this shift-
     // assignment if we have room.
-    if (static_cast<SourceType>(n) < sourceTypeLength) {
+    if (static_cast<SourceType>(n) < numBits<SourceType>()) {
       m_bits >>= static_cast<SourceType>(n);
     }
     m_numBits -= n;

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -40,7 +40,7 @@ template <typename Source>
 template <typename T>
 T BitStream<Source>::next(int nbits, std::false_type) {
   using SourceType = decltype(m_source.next());
-  auto sourceTypeLength = (sizeof(SourceType) * 8);
+  SourceType sourceTypeLength = (sizeof(SourceType) * 8);
 
   if (nbits == 0) {
     return 0;

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <tuple>
+#include <limits>
 
 namespace rc {
 namespace detail {

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -96,7 +96,7 @@ inline uint64_t avalanche(uint64_t x) {
 template <typename T>
 constexpr T bitMask(int nbits) {
   // Avoid undefined behavior by never left-shifting a negative number.
-  auto left = (~static_cast<T>(0) - 1) ? (~static_cast<T>(0) - 1) : 0;
+  auto left  = (~static_cast<T>(0) - 1) > 0 ? (~static_cast<T>(0) - 1) : 0;
   return ~(left << static_cast<T>(nbits - 1));
 }
 

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -98,7 +98,7 @@ constexpr T bitMask(int nbits) {
   // Avoid undefined behavior by operating on unsigned numbers (`UT`), and then
   // casting back to T.
   using UT = typename std::make_unsigned<T>::type;
-  return (T)(~((~static_cast<UT>(0) - 1) << static_cast<UT>(nbits - 1)));
+  return (T)(~(~static_cast<UT>(0) << static_cast<UT>(nbits)));
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -95,9 +95,10 @@ inline uint64_t avalanche(uint64_t x) {
 /// and the rest set to 0.
 template <typename T>
 constexpr T bitMask(int nbits) {
-  // Avoid undefined behavior by never left-shifting a negative number.
-  auto left  = (~static_cast<T>(0) - 1) > 0 ? (~static_cast<T>(0) - 1) : 0;
-  return ~(left << static_cast<T>(nbits - 1));
+  // Avoid undefined behavior by operating on unsigned numbers (`UT`), and then
+  // casting back to T.
+  typedef typename std::make_unsigned<T>::type UT;
+  return (T)(~((~static_cast<UT>(0) - 1) << static_cast<UT>(nbits - 1)));
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -97,7 +97,7 @@ template <typename T>
 constexpr T bitMask(int nbits) {
   // Avoid undefined behavior by operating on unsigned numbers (`UT`), and then
   // casting back to T.
-  typedef typename std::make_unsigned<T>::type UT;
+  using UT = typename std::make_unsigned<T>::type;
   return (T)(~((~static_cast<UT>(0) - 1) << static_cast<UT>(nbits - 1)));
 }
 

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -95,7 +95,9 @@ inline uint64_t avalanche(uint64_t x) {
 /// and the rest set to 0.
 template <typename T>
 constexpr T bitMask(int nbits) {
-  return ~((~static_cast<T>(0) - 1) << static_cast<T>(nbits - 1));
+  // Avoid undefined behavior by never left-shifting a negative number.
+  auto left = (~static_cast<T>(0) - 1) ? (~static_cast<T>(0) - 1) : 0;
+  return ~(left << static_cast<T>(nbits - 1));
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -101,10 +101,10 @@ constexpr T bitMask(int nbits) {
   //   1. Shifting past the width of a type (ex `<< 32` against an `int32_t`)
   //   2. Shifting a negative operand (which `~0` is for all signed types)
   // First we branch to avoid shifting the past the width of the type, then
-  // (assuming we are shifting, and aren't just returning `~0`) we cast `~0`
-  // to an explicitly unsigned type before performing the shift.
-  return nbits != std::numeric_limits<UT>::digits ?
-         ~T(~UT(0) << nbits)                      :
+  // (assuming we are shifting, and aren't just returning `~0`) we cast `0`
+  // to an explicitly unsigned type before performing bitwise NOT and shift.
+  return nbits < std::numeric_limits<UT>::digits ?
+         ~T(~UT(0) << nbits)                     :
          ~T(0);
 }
 

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -99,12 +99,12 @@ constexpr T bitMask(int nbits) {
   // There are two pieces of undefined behavior we're avoiding here,
   //   1. Shifting past the width of a type (ex `<< 32` against an `int32_t`)
   //   2. Shifting a negative operand (which `~0` is for all signed types)
-  // First we branch to avoid shifting the bit-width of the given type, then
-  // (assuming we are shifting, and aren't just returning all 1s) we cast `~0`
-  // to an explicitly signed type before performing the shift.
-  return nbits != sizeof(T) * 8                            ?
-         static_cast<T>(~(static_cast<UT>(~(0)) << nbits)) :
-         static_cast<T>(~(0));
+  // First we branch to avoid shifting the past the width of the type, then
+  // (assuming we are shifting, and aren't just returning all `~0`) we cast `~0`
+  // to an explicitly unsigned type before performing the shift.
+  return nbits != std::numeric_limits<UT>::digits ?
+         ~T(~UT(0) << nbits)                      :
+         ~T(0);
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -100,11 +100,11 @@ constexpr T bitMask(int nbits) {
   //   1. Shifting past the width of a type (ex `<< 32` against an `int32_t`)
   //   2. Shifting a negative operand (which `~0` is for all signed types)
   // First we branch to avoid shifting the past the width of the type, then
-  // (assuming we are shifting, and aren't just returning all `~0`) we cast `~0`
+  // (assuming we are shifting, and aren't just returning `~0`) we cast `~0`
   // to an explicitly unsigned type before performing the shift.
   return nbits != std::numeric_limits<UT>::digits ?
-         ~T(~UT(0) << nbits)                      :
-         ~T(0);
+                  ~T(~UT(0) << nbits)             :
+                  ~T(0);
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -103,8 +103,8 @@ constexpr T bitMask(int nbits) {
   // (assuming we are shifting, and aren't just returning `~0`) we cast `~0`
   // to an explicitly unsigned type before performing the shift.
   return nbits != std::numeric_limits<UT>::digits ?
-                  ~T(~UT(0) << nbits)             :
-                  ~T(0);
+         ~T(~UT(0) << nbits)                      :
+         ~T(0);
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -95,10 +95,16 @@ inline uint64_t avalanche(uint64_t x) {
 /// and the rest set to 0.
 template <typename T>
 constexpr T bitMask(int nbits) {
-  // Avoid undefined behavior by operating on unsigned numbers (`UT`), and then
-  // casting back to T.
   using UT = typename std::make_unsigned<T>::type;
-  return (T)(~(~static_cast<UT>(0) << static_cast<UT>(nbits)));
+  // There are two pieces of undefined behavior we're avoiding here,
+  //   1. Shifting past the width of a type (ex `<< 32` against an `int32_t`)
+  //   2. Shifting a negative operand (which `~0` is for all signed types)
+  // First we branch to avoid shifting the bit-width of the given type, then
+  // (assuming we are shifting, and aren't just returning all 1s) we cast `~0`
+  // to an explicitly signed type before performing the shift.
+  return nbits != sizeof(T) * 8                            ?
+         static_cast<T>(~(static_cast<UT>(~(0)) << nbits)) :
+         static_cast<T>(~(0));
 }
 
 // TODO separate into header and implementation file

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -117,7 +117,7 @@ TEST_CASE("BitStream") {
            const auto n = *gen::inRange(0, 64);
            const bool sign = (x & (1LL << (n - 1LL))) != 0;
            const auto mask = ~bitMask<int64_t>(n);
-           if (sign) {
+           if (sign && n > 0) {
              RC_ASSERT((stream.next<int64_t>(n) & mask) == mask);
            } else {
              RC_ASSERT((stream.next<int64_t>(n) & mask) == 0);

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -128,14 +128,14 @@ TEST_CASE("BitStream") {
          [=](uint64_t x) {
            auto source = makeSource(seq::repeat(x));
            auto stream = bitStreamOf(source);
-           RC_ASSERT((stream.next<uint64_t>(0) & bitMask<uint64_t>(64)) == 0U);
+           RC_ASSERT(stream.next<uint64_t>(0) == 0U);
          });
 
     prop("does not return any bits when none are requested (signed)",
          [=](uint64_t x) {
            auto source = makeSource(seq::repeat(x));
            auto stream = bitStreamOf(source);
-           RC_ASSERT((stream.next<int64_t>(0) & bitMask<int64_t>(64)) == 0);
+           RC_ASSERT(stream.next<int64_t>(0) == 0);
          });
 
     prop("works with booleans",

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -106,7 +106,7 @@ TEST_CASE("BitStream") {
          [=](uint64_t x) {
            auto source = makeSource(seq::repeat(x));
            auto stream = bitStreamOf(source);
-           int n = *gen::inRange(0, 64);
+           int n = *gen::inRange(1, 64);
            RC_ASSERT((stream.next<uint64_t>(n) & ~bitMask<uint64_t>(n)) == 0U);
          });
 
@@ -114,14 +114,28 @@ TEST_CASE("BitStream") {
          [=](uint64_t x) {
            auto source = makeSource(seq::repeat(x));
            auto stream = bitStreamOf(source);
-           const auto n = *gen::inRange(0, 64);
+           const auto n = *gen::inRange(1, 64);
            const bool sign = (x & (1LL << (n - 1LL))) != 0;
            const auto mask = ~bitMask<int64_t>(n);
-           if (sign && n > 0) {
+           if (sign) {
              RC_ASSERT((stream.next<int64_t>(n) & mask) == mask);
            } else {
              RC_ASSERT((stream.next<int64_t>(n) & mask) == 0);
            }
+         });
+
+    prop("does not return any bits when none are requested",
+         [=](uint64_t x) {
+           auto source = makeSource(seq::repeat(x));
+           auto stream = bitStreamOf(source);
+           RC_ASSERT((stream.next<uint64_t>(0) & bitMask<uint64_t>(64)) == 0U);
+         });
+
+    prop("does not return any bits when none are requested (signed)",
+         [=](uint64_t x) {
+           auto source = makeSource(seq::repeat(x));
+           auto stream = bitStreamOf(source);
+           RC_ASSERT((stream.next<int64_t>(0) & bitMask<int64_t>(64)) == 0);
          });
 
     prop("works with booleans",


### PR DESCRIPTION
Using GCC 6.3.1 and the `-fsanitize=address,undefined` compile flags, a project I've been testing using RapidCheck has been throwing the below failures (NB. the paths are munged to be more readable),

```
./include/rapidcheck/detail/BitStream.hpp:60:12: runtime error: shift exponent 64 is too large for 64-bit type 'uint64_t' (aka 'unsigned long')
SUMMARY: AddressSanitizer: undefined-behavior ./include/rapidcheck/detail/BitStream.hpp:60:12
```

```
./include/rapidcheck/detail/Utility.h:98:37: runtime error: left shift of negative value -2
SUMMARY: AddressSanitizer: undefined-behavior ./include/rapidcheck/detail/Utility.h:98:37
```

This PR aims to avoid these undefined bit-shift behaviors and -- in admittedly very loose, "Does it work on my machine?" tests -- seems to do the job.