### PR TITLE
let clang build on Windows

### DIFF
--- a/src/detail/Platform.cpp
+++ b/src/detail/Platform.cpp
@@ -51,11 +51,10 @@ std::string demangle(const char *name) {
 
 Maybe<std::string> getEnvValue(const std::string &name) {
   char *buffer = nullptr;
-  const auto ret = _dupenv_s(&buffer, nullptr, name.c_str());
-  const auto ptr = std::unique_ptr<char, decltype(&std::free)>(buffer, &std::free);
+  _dupenv_s(&buffer, nullptr, name.c_str());
 
   if (buffer != nullptr) {
-    return buffer;
+    return std::string(buffer);
   } else {
     return Nothing;
   }

--- a/src/detail/Platform.cpp
+++ b/src/detail/Platform.cpp
@@ -52,6 +52,7 @@ std::string demangle(const char *name) {
 Maybe<std::string> getEnvValue(const std::string &name) {
   char *buffer = nullptr;
   _dupenv_s(&buffer, nullptr, name.c_str());
+  const auto ptr = std::unique_ptr<char, decltype(&std::free)>(buffer, &std::free);
 
   if (buffer != nullptr) {
     return std::string(buffer);


### PR DESCRIPTION
Allow building with clang 4.0 compiler under Windows.
Remove unused variables (cmake file has /WX - warnings are errors) and
make explicit in one stage of a 2 stage type conversion (char* -> std::string ->
Maybe) all in one function.