### PR TITLE
Add support for parameterized Google Test cases

### DIFF
--- a/doc/gtest.md
+++ b/doc/gtest.md
@@ -35,5 +35,11 @@ Analogous to the Google Test `TEST_F` macro, defines a RapidCheck property as a 
 
 Since this macro is implemented in terms of Google Test's `TEST` macro and Google Test does not allow mixing of `TEST` and `TEST_F` for the same test case, test cases, a property tied to a fixture named `Fixture` will be registered under a test case named `Fixed_RapidCheck`. This is usually not a big issue but is something to be aware of, in particular when filtering Google Test case names from the command line.
 
+There are also additional macros to instatiate parameterized test cases:
+
+* `RC_GTEST_PROP_P(Fixture, Name, (args...))` for [Google Test value-parameterized tests](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#value-parameterized-tests) (`TEST_P`)
+* `RC_GTEST_PROP_TYPED(Fixture, Name, (args...))` for [Google Test typed tests](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#typed-tests) (`TYPED_TEST`)
+* `RC_GTEST_PROP_TYPED_P(Fixture, Name, (args...))` for [Google Test type-parameterized tests](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#type-parameterized-tests) (`TYPED_TEST_P`)
+
 ## Assertions ##
 RapidCheck will treat any exception as a property failure so you should be able to use any assertion mechanism that signals failures as exceptions. However, Google Test assertions are not implemented using exceptions which means that you should avoid them and use RapidCheck assertions such as `RC_ASSERT` in your RapidCheck properties instead.

--- a/extras/gtest/include/rapidcheck/gtest.h
+++ b/extras/gtest/include/rapidcheck/gtest.h
@@ -46,6 +46,24 @@ void checkGTest(Testable &&testable) {
 /// Defines a RapidCheck property as a Google Test fixture based test. The
 /// fixture is reinstantiated for each test case of the property.
 #define RC_GTEST_FIXTURE_PROP(Fixture, Name, ArgList)                          \
+  RC_GTEST_FIXTURE_GEN(TEST_F, Fixture, Name, ArgList)
+
+/// Defines a RapidCheck property as a Google Test value-parameterized
+/// test. The fixture is reinstantiated for each test case of the property.
+#define RC_GTEST_PROP_P(Fixture, Name, ArgList)                                \
+  RC_GTEST_FIXTURE_GEN(TEST_P, Fixture, Name, ArgList)
+
+/// Defines a RapidCheck property as a Google Test typed test. The
+/// fixture is reinstantiated for each test case of the property.
+#define RC_GTEST_PROP_TYPED(Fixture, Name, ArgList)                            \
+  RC_GTEST_FIXTURE_GEN(TYPED_TEST, Fixture, Name, ArgList)
+
+/// Defines a RapidCheck property as a Google Test type-parameterized
+/// test. The fixture is reinstantiated for each test case of the property.
+#define RC_GTEST_PROP_TYPED_P(Fixture, Name, ArgList)                          \
+  RC_GTEST_FIXTURE_GEN(TYPED_TEST_P, Fixture, Name, ArgList)
+
+#define RC_GTEST_FIXTURE_GEN(TestDeclaration, Fixture, Name, ArgList)          \
   class RapidCheckPropImpl_##Fixture##_##Name : public Fixture {               \
   public:                                                                      \
     void rapidCheck_fixtureSetUp() { SetUp(); }                                \
@@ -54,7 +72,7 @@ void checkGTest(Testable &&testable) {
     void rapidCheck_fixtureTearDown() { TearDown(); }                          \
   };                                                                           \
                                                                                \
-  TEST(Fixture##_RapidCheck, Name) {                                           \
+  TestDeclaration(Fixture##_RapidCheck, Name) {                                \
     ::rc::detail::checkGTest(&rc::detail::ExecFixture<                         \
                              RapidCheckPropImpl_##Fixture##_##Name>::exec);    \
   }                                                                            \


### PR DESCRIPTION
In order to support paramererized Google Test cases, the following
macros were added:

* RC_GTEST_PROP_P
* RC_GTEST_PROP_TYPED
* RC_GTEST_PROP_TYPED_P

They behave like regular fixture test cases, but invoke different
gtest macros. Although there is some overlap between RapidCheck's
functionality and value-parameterized tests, there are legitimate use
cases for using a combination of both, ie. some test cases of a
fixture using RapidCheck and some not, but all being parameterized on
different implementations to some interface.