### PR TITLE
Use NEW settings for CMP0063 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(rapidcheck)
+
+# Don't warn about symbol visibility for static libraries with CMake 3.3 and later.
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 enable_testing()
 
 option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)


### PR DESCRIPTION
This removes warnings when using CMake >= 3.3 if you have symbol visibility set.

Or you could change the minimum version to 3.3. There are only 6 policy changes since then and it is now 2 years old. Ubuntu 16.04 LTS has CMake 3.5 for comparison.

No doubt Debian Stable has some ancient version but they love that. :-)