### PR TITLE
Various fixes

### DIFF
--- a/include/rapidcheck/gen/Maybe.hpp
+++ b/include/rapidcheck/gen/Maybe.hpp
@@ -18,7 +18,7 @@ public:
     }
 
     return prependNothing(shrinkable::map(
-        m_gen(r, size), [](T &&x) -> Maybe<T> { return std::move(x); }));
+        m_gen(r, size), [](T &&y) -> Maybe<T> { return std::move(y); }));
   }
 
 private:

--- a/include/rapidcheck/gen/Maybe.hpp
+++ b/include/rapidcheck/gen/Maybe.hpp
@@ -30,7 +30,7 @@ private:
               seq::just(shrinkable::lambda([] { return Maybe<T>(); })),
               seq::map(std::move(shrinks), &prependNothing));
         });
-  };
+  }
 
   Gen<T> m_gen;
 };

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -167,7 +167,7 @@ Seq<T> real(T value) {
   std::vector<T> shrinks;
 
   if (value != 0) {
-    shrinks.push_back(0.0);
+    shrinks.push_back(T(0.0));
   }
 
   if (value < 0) {

--- a/src/detail/Platform.cpp
+++ b/src/detail/Platform.cpp
@@ -66,7 +66,7 @@ Maybe<std::string> getEnvValue(const std::string &name) {
 std::string demangle(const char *name) {
   std::string demangled(name);
   int status;
-  char *buf = abi::__cxa_demangle(name, 0, 0, &status);
+  char *buf = abi::__cxa_demangle(name, nullptr, nullptr, &status);
   if (status == 0) {
     demangled = std::string(buf);
   }

--- a/src/detail/Results.cpp
+++ b/src/detail/Results.cpp
@@ -89,7 +89,7 @@ std::ostream &operator<<(std::ostream &os,
   return os;
 }
 
-void printDistribution(const SuccessResult &result, std::ostream &os) {
+static void printDistribution(const SuccessResult &result, std::ostream &os) {
   using Entry = std::pair<Tags, int>;
   std::vector<Entry> entries(begin(result.distribution),
                              end(result.distribution));
@@ -210,7 +210,7 @@ bool operator!=(const Error &lhs, const Error &rhs) {
   return !(lhs == rhs);
 }
 
-void printResultMessage(const Error &result, std::ostream &os) {
+static void printResultMessage(const Error &result, std::ostream &os) {
   os << "Failure: " << result.description << std::endl;
   os << std::endl;
 }

--- a/src/detail/Results.cpp
+++ b/src/detail/Results.cpp
@@ -89,7 +89,8 @@ std::ostream &operator<<(std::ostream &os,
   return os;
 }
 
-static void printDistribution(const SuccessResult &result, std::ostream &os) {
+namespace {
+void printDistribution(const SuccessResult &result, std::ostream &os) {
   using Entry = std::pair<Tags, int>;
   std::vector<Entry> entries(begin(result.distribution),
                              end(result.distribution));
@@ -112,6 +113,7 @@ static void printDistribution(const SuccessResult &result, std::ostream &os) {
     }
     os << std::endl;
   }
+}
 }
 
 void printResultMessage(const SuccessResult &result, std::ostream &os) {
@@ -210,9 +212,11 @@ bool operator!=(const Error &lhs, const Error &rhs) {
   return !(lhs == rhs);
 }
 
-static void printResultMessage(const Error &result, std::ostream &os) {
+namespace {
+void printResultMessage(const Error &result, std::ostream &os) {
   os << "Failure: " << result.description << std::endl;
   os << std::endl;
+}
 }
 
 //

--- a/test/CheckTests.cpp
+++ b/test/CheckTests.cpp
@@ -23,9 +23,9 @@ TEST_CASE("checkTestable") {
          Maybe<std::tuple<TestMetadata, TestResult>> callbackParams;
          MockTestListener listener;
          listener.onTestFinishedCallback =
-             [&](const TestMetadata &metadata, const TestResult &result) {
+             [&](const TestMetadata &lambdaMetadata, const TestResult &result) {
                RC_ASSERT(!callbackParams);
-               callbackParams.init(metadata, result);
+               callbackParams.init(lambdaMetadata, result);
              };
 
          const auto result = checkTestable([&] {

--- a/test/GenTests.cpp
+++ b/test/GenTests.cpp
@@ -46,10 +46,10 @@ TEST_CASE("Gen") {
            bool called = false;
            Random passedRandom;
            int passedSize;
-           Gen<int> gen([&](const Random &random, int size) {
+           Gen<int> gen([&](const Random &lambdaRandom, int lambdaSize) {
              called = true;
-             passedRandom = random;
-             passedSize = size;
+             passedRandom = lambdaRandom;
+             passedSize = lambdaSize;
              return shrinkable::just(0);
            });
 
@@ -61,7 +61,7 @@ TEST_CASE("Gen") {
 
     prop("returns the value returned by the functor",
          [](const Random &random, int size, int x) {
-           Gen<int> gen([=](const Random &random, int size) {
+           Gen<int> gen([=](const Random &lambdaRandom, int lambdaSize) {
              return shrinkable::just(x);
            });
 

--- a/test/RandomTests.cpp
+++ b/test/RandomTests.cpp
@@ -169,9 +169,9 @@ TEST_CASE("Random") {
          double error = std::accumulate(begin(bins),
                                         end(bins),
                                         0.0,
-                                        [=](double error, std::uint64_t x) {
+                                        [=](double lambdaError, std::uint64_t x) {
                                           double diff = 1.0 - (x / ideal);
-                                          return error + (diff * diff);
+                                          return lambdaError + (diff * diff);
                                         });
 
          RC_ASSERT(error < 0.01);

--- a/test/RandomTests.cpp
+++ b/test/RandomTests.cpp
@@ -34,7 +34,7 @@ struct AssociativeProperties {
 
                          RC_ASSERT(extracted == pairs);
                        });
-  };
+  }
 };
 }
 

--- a/test/SeqTests.cpp
+++ b/test/SeqTests.cpp
@@ -14,8 +14,6 @@ namespace {
 
 class LoggingSeqImpl : public Logger {
 public:
-  LoggingSeqImpl()
-      : Logger() {}
   LoggingSeqImpl(std::string theId)
       : Logger(std::move(theId)) {}
 

--- a/test/ShrinkableTests.cpp
+++ b/test/ShrinkableTests.cpp
@@ -45,8 +45,6 @@ class LoggingShrinkableImpl : public Logger {
 public:
   using IdLogPair = std::pair<std::string, std::vector<std::string>>;
 
-  LoggingShrinkableImpl()
-      : Logger() {}
   LoggingShrinkableImpl(std::string theId)
       : Logger(std::move(theId)) {}
 

--- a/test/detail/ApplyTupleTests.cpp
+++ b/test/detail/ApplyTupleTests.cpp
@@ -9,7 +9,7 @@ using namespace rc;
 using namespace rc::test;
 using namespace rc::detail;
 
-std::tuple<int, std::string, std::vector<std::string>>
+static std::tuple<int, std::string, std::vector<std::string>>
 myFunc(int x, int y, Logger logger) {
   return std::make_tuple(x + y, logger.id, logger.log);
 }

--- a/test/detail/ApplyTupleTests.cpp
+++ b/test/detail/ApplyTupleTests.cpp
@@ -9,9 +9,11 @@ using namespace rc;
 using namespace rc::test;
 using namespace rc::detail;
 
-static std::tuple<int, std::string, std::vector<std::string>>
+namespace {
+std::tuple<int, std::string, std::vector<std::string>>
 myFunc(int x, int y, Logger logger) {
   return std::make_tuple(x + y, logger.id, logger.log);
+}
 }
 
 TEST_CASE("applyTuple") {

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -68,9 +68,9 @@ TEST_CASE("BitStream") {
            auto stream = bitStreamOf(source);
 
            const auto sizes = *gen::suchThat(bitSizes,
-                                       [](const std::vector<int> &x) {
+                                       [](const std::vector<int> &y) {
                                          return std::accumulate(
-                                                    begin(x), end(x), 0) >= 64;
+                                                    begin(y), end(y), 0) >= 64;
                                        });
 
            uint64_t value = 0;

--- a/test/detail/ImplicitParamTests.cpp
+++ b/test/detail/ImplicitParamTests.cpp
@@ -253,8 +253,8 @@ TEST_CASE("ImplicitParam") {
       SECTION(
           "with new scope and binding, value() the value of that"
           " binding") {
-        ImplicitParam<ParamA> a1("bind!");
-        ImplicitParam<ParamB> b1(101);
+        ImplicitParam<ParamA> a2("bind!");
+        ImplicitParam<ParamB> b2(101);
         REQUIRE(ImplicitParam<ParamA>::value() == "bind!");
         REQUIRE(ImplicitParam<ParamB>::value() == 101);
       }

--- a/test/detail/LogTestListenerTests.cpp
+++ b/test/detail/LogTestListenerTests.cpp
@@ -26,7 +26,6 @@ TEST_CASE("LogTestListener") {
 
   SECTION("when verbose progress is on") {
     LogTestListener listener(os, true, false);
-    CaseDescription desc;
 
     SECTION("prints '.' on successful test case") {
       desc.result.type = CaseResult::Type::Success;

--- a/test/detail/PropertyTests.cpp
+++ b/test/detail/PropertyTests.cpp
@@ -219,8 +219,8 @@ TEST_CASE("PropertyAdapter") {
        [](int a, const std::string &b, NonCopyable c) {
          const auto expected = std::to_string(a) + b + std::to_string(c.extra);
          const auto adapter =
-             makeAdapter([](int a, const std::string &b, NonCopyable c) {
-               return std::to_string(a) + b + std::to_string(c.extra);
+             makeAdapter([](int d, const std::string &e, NonCopyable f) {
+               return std::to_string(d) + e + std::to_string(f.extra);
              });
          const auto result = adapter(std::move(a), std::move(b), std::move(c));
          RC_ASSERT(result.result.description == expected);

--- a/test/detail/PropertyTests.cpp
+++ b/test/detail/PropertyTests.cpp
@@ -243,11 +243,6 @@ namespace {
 template <int N>
 struct Fixed {};
 
-template <int N>
-void showValue(std::ostream &os, const Fixed<N> &) {
-  os << N;
-}
-
 } // namespace
 
 namespace rc {

--- a/test/detail/SerializationTests/Misc.cpp
+++ b/test/detail/SerializationTests/Misc.cpp
@@ -53,11 +53,6 @@ namespace {
 
 struct NonDeserializable {};
 
-template <typename Iterator>
-Iterator deserialize(Iterator begin, Iterator end, NonDeserializable &output) {
-  return begin;
-}
-
 } // namespace
 
 TEST_CASE("deserializeN") {

--- a/test/detail/TestingTests.cpp
+++ b/test/detail/TestingTests.cpp
@@ -262,7 +262,7 @@ TEST_CASE("searchProperty") {
        });
 }
 
-Shrinkable<CaseDescription> countdownEven(int start) {
+static Shrinkable<CaseDescription> countdownEven(int start) {
   return shrinkable::map(countdownShrinkable(start),
                          [=](int x) {
                            CaseDescription desc;

--- a/test/detail/TestingTests.cpp
+++ b/test/detail/TestingTests.cpp
@@ -262,7 +262,8 @@ TEST_CASE("searchProperty") {
        });
 }
 
-static Shrinkable<CaseDescription> countdownEven(int start) {
+namespace {
+Shrinkable<CaseDescription> countdownEven(int start) {
   return shrinkable::map(countdownShrinkable(start),
                          [=](int x) {
                            CaseDescription desc;
@@ -272,6 +273,7 @@ static Shrinkable<CaseDescription> countdownEven(int start) {
                            desc.result.description = std::to_string(x);
                            return desc;
                          });
+}
 }
 
 TEST_CASE("shrinkTestCase") {

--- a/test/detail/VariantTests.cpp
+++ b/test/detail/VariantTests.cpp
@@ -28,11 +28,6 @@ bool operator==(const X<N> &x1, const X<N> &x2) {
   return x1.value == x2.value;
 }
 
-template <std::size_t N>
-bool operator!=(const X<N> &x1, const X<N> &x2) {
-  return x1.value != x2.value;
-}
-
 using A = X<5>;
 using B = X<10>;
 using C = X<15>;

--- a/test/gen/NumericTests.cpp
+++ b/test/gen/NumericTests.cpp
@@ -35,13 +35,6 @@ typename std::make_unsigned<T>::type absolute(T x) {
   return absoluteInt(x, std::is_signed<T>());
 }
 
-template <
-    typename T,
-    typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
-T absolute(T x) {
-  return std::abs(x);
-}
-
 template <typename T>
 bool isAllOnes(T x) {
   using UInt = typename std::make_unsigned<T>::type;

--- a/test/gen/NumericTests.cpp
+++ b/test/gen/NumericTests.cpp
@@ -85,9 +85,9 @@ struct IntegralProperties {
             const auto error = std::accumulate(begin(bins),
                                            end(bins),
                                            0.0,
-                                           [=](double error, uint64_t x) {
+                                           [=](double lambdaError, uint64_t x) {
                                              double diff = 1.0 - (x / ideal);
-                                             return error + (diff * diff);
+                                             return lambdaError + (diff * diff);
                                            });
 
             RC_ASSERT(error < 0.1);

--- a/test/gen/detail/ExecRawTests.cpp
+++ b/test/gen/detail/ExecRawTests.cpp
@@ -154,12 +154,12 @@ TEST_CASE("execRaw") {
        [](const Random &initial) {
          const auto n = *gen::inRange<std::size_t>(1, 10);
          const auto randoms = execRaw([=](const PassedRandom &rnd) {
-           std::set<Random> randoms;
-           randoms.insert(rnd.value);
-           while (randoms.size() < n) {
-             randoms.insert(*genRandom());
+           std::set<Random> lambdaRandoms;
+           lambdaRandoms.insert(rnd.value);
+           while (lambdaRandoms.size() < n) {
+             lambdaRandoms.insert(*genRandom());
            }
-           return randoms;
+           return lambdaRandoms;
          })(initial, 0).value().first;
 
          RC_ASSERT(randoms.size() == n);

--- a/test/shrink/ShrinkTests.cpp
+++ b/test/shrink/ShrinkTests.cpp
@@ -228,13 +228,13 @@ struct RealProperties {
         });
 
     TEMPLATED_SECTION(T, "zero has no shrinks") {
-      REQUIRE(!shrink::real<T>(0.0).next());
+      REQUIRE(!shrink::real<T>(T(0.0)).next());
     }
 
     templatedProp<T>("tries 0.0 first",
                      [] {
                        T value = *gen::nonZero<T>();
-                       RC_ASSERT(*shrink::real<T>(value).next() == 0.0);
+                       RC_ASSERT(*shrink::real<T>(value).next() == T(0.0));
                      });
 
     templatedProp<T>(

--- a/test/shrinkable/CreateTests.cpp
+++ b/test/shrinkable/CreateTests.cpp
@@ -92,7 +92,7 @@ TEST_CASE("shrinkable::shrinkRecur") {
              *gen::container<std::vector<bool>>(start, gen::arbitrary<bool>());
 
          const auto shrink = [](int x) {
-           return seq::map(seq::range(x, 0), [](int x) { return x - 1; });
+           return seq::map(seq::range(x, 0), [](int y) { return y - 1; });
          };
 
          auto shrinkable = shrinkable::shrinkRecur(start, shrink);

--- a/test/shrinkable/OperationsTests.cpp
+++ b/test/shrinkable/OperationsTests.cpp
@@ -14,7 +14,7 @@ TEST_CASE("shrinkable::all") {
          // TODO sized ranged
          int x = *gen::inRange<int>(1, 5);
          const auto shrinkable = shrinkable::shrinkRecur(
-             x, [](int x) { return seq::range(x - 1, 0); });
+             x, [](int y) { return seq::range(y - 1, 0); });
 
          RC_ASSERT(shrinkable::all(
              shrinkable,
@@ -101,10 +101,10 @@ TEST_CASE("shrinkable::walkPath") {
                                gen::inRange<std::size_t>(0, 100));
          const auto shrinkable =
              shrinkable::shrinkRecur(std::vector<std::size_t>(),
-                                     [](const std::vector<std::size_t> &path) {
+                                     [](const std::vector<std::size_t> &lambdaPath) {
                                        return seq::map(seq::index(),
                                                        [=](std::size_t i) {
-                                                         auto p = path;
+                                                         auto p = lambdaPath;
                                                          p.push_back(i);
                                                          return p;
                                                        });

--- a/test/shrinkable/TransformTests.cpp
+++ b/test/shrinkable/TransformTests.cpp
@@ -36,8 +36,8 @@ TEST_CASE("shrinkable::map") {
 TEST_CASE("shrinkable::mapShrinks") {
   prop("maps shrinks with the given mapping callable",
        [](Shrinkable<int> shrinkable) {
-         const auto mapper = [](Seq<Shrinkable<int>> &&shrinkable) {
-           return seq::map(std::move(shrinkable),
+         const auto mapper = [](Seq<Shrinkable<int>> &&lambdaShrinkable) {
+           return seq::map(std::move(lambdaShrinkable),
                            [](const Shrinkable<int> &shrink) {
                              return shrinkable::just(shrink.value());
                            });
@@ -162,7 +162,7 @@ TEST_CASE("shrinkable::mapcat") {
          const auto shrink = *seq::at(shrinkable.shrinks(), n);
          onAnyPath(shrink,
                    [=](const Shrinkable<std::pair<int, int>> &value,
-                       const Shrinkable<std::pair<int, int>> &shrink) {
+                       const Shrinkable<std::pair<int, int>> &lambdaShrink) {
                      RC_ASSERT(value.value().first == firstValue);
                    });
        });

--- a/test/shrinkable/TransformTests.cpp
+++ b/test/shrinkable/TransformTests.cpp
@@ -11,7 +11,7 @@
 using namespace rc;
 using namespace rc::test;
 
-int doubleIt(int x) { return x * 2; }
+static int doubleIt(int x) { return x * 2; }
 
 TEST_CASE("shrinkable::map") {
   prop("maps value()",

--- a/test/shrinkable/TransformTests.cpp
+++ b/test/shrinkable/TransformTests.cpp
@@ -11,7 +11,9 @@
 using namespace rc;
 using namespace rc::test;
 
-static int doubleIt(int x) { return x * 2; }
+namespace {
+int doubleIt(int x) { return x * 2; }
+}
 
 TEST_CASE("shrinkable::map") {
   prop("maps value()",

--- a/test/state/gen/CommandsTests.cpp
+++ b/test/state/gen/CommandsTests.cpp
@@ -35,10 +35,10 @@ std::vector<GenParams> collectParams(const IntVecCmds &cmds) {
                  [](const IntVecCmdSP &cmd) {
                    const auto paramsCmd =
                        std::static_pointer_cast<const ParamsCmd>(cmd);
-                   GenParams params;
-                   params.random = paramsCmd->random;
-                   params.size = paramsCmd->size;
-                   return params;
+                   GenParams lambdaParams;
+                   lambdaParams.random = paramsCmd->random;
+                   lambdaParams.size = paramsCmd->size;
+                   return lambdaParams;
                  });
   return params;
 }
@@ -49,7 +49,7 @@ std::set<Random> collectRandoms(const IntVecCmds &cmds) {
   std::transform(begin(params),
                  end(params),
                  std::inserter(randoms, randoms.end()),
-                 [](const GenParams &params) { return params.random; });
+                 [](const GenParams &lambdaParams) { return lambdaParams.random; });
   return randoms;
 }
 
@@ -162,8 +162,8 @@ TEST_CASE("state::gen::commands") {
                      auto sut = s0;
                      runAll(value.value(), s0, sut);
                      int x = 0;
-                     for (int value : sut) {
-                       RC_ASSERT(value == x++);
+                     for (int lambdaValue : sut) {
+                       RC_ASSERT(lambdaValue == x++);
                      }
                    });
        });

--- a/test/state/gen/ExecCommandsTests.cpp
+++ b/test/state/gen/ExecCommandsTests.cpp
@@ -16,7 +16,6 @@ struct B : public IntVecCmd {};
 struct C : public IntVecCmd {};
 
 struct StateConstructible : public IntVecCmd {
-  StateConstructible() = default;
   StateConstructible(const IntVec &s)
       : state(s)
       , generated(*gen::just(s)) {}
@@ -26,7 +25,6 @@ struct StateConstructible : public IntVecCmd {
 };
 
 struct ArgsConstructible : public IntVecCmd {
-  ArgsConstructible() = default;
   ArgsConstructible(const std::string &s, int n)
       : str(s)
       , num(n) {}
@@ -41,10 +39,6 @@ struct GeneratesOnConstrution : public IntVecCmd {
       : value(*gen::just(v)) {}
 
   T value;
-};
-
-struct AlwaysDiscard : public IntVecCmd {
-  AlwaysDiscard() { RC_DISCARD("Nope"); }
 };
 
 } // namespace

--- a/test/util/Generators.h
+++ b/test/util/Generators.h
@@ -155,7 +155,7 @@ struct Arbitrary<detail::Variant<T, Ts...>> {
     return gen::oneOf(
         gen::cast<detail::Variant<T, Ts...>>(gen::arbitrary<T>()),
         gen::cast<detail::Variant<T, Ts...>>(gen::arbitrary<Ts>())...);
-  };
+  }
 };
 
 } // namespace rc

--- a/test/util/IntVec.h
+++ b/test/util/IntVec.h
@@ -51,7 +51,7 @@ struct PreNeverHolds : public IntVecCmd {
 };
 
 struct DiscardInConstructor : public IntVecCmd {
-  DiscardInConstructor(const IntVec &s0) { RC_DISCARD(); }
+  [[noreturn]] DiscardInConstructor(const IntVec &s0) { RC_DISCARD(); }
 
   void show(std::ostream &os) const override { os << "DiscardInConstructor"; }
 };

--- a/test/util/ThrowOnCopy.h
+++ b/test/util/ThrowOnCopy.h
@@ -10,7 +10,7 @@ struct ThrowOnCopy {
   ThrowOnCopy(std::string s)
       : value(std::move(s)) {}
 
-  ThrowOnCopy(const ThrowOnCopy &) { throw std::runtime_error("can't copy"); }
+  [[noreturn]] ThrowOnCopy(const ThrowOnCopy &) { throw std::runtime_error("can't copy"); }
 
   ThrowOnCopy &operator=(const ThrowOnCopy &) {
     throw std::runtime_error("can't copy");


### PR DESCRIPTION
Bunch of small fixes. Feel free to cherry-pick specific commits if you don't want it all.

This allows for compilation with clang 5's options:
`-Weverything -Wno-c++98-compat -Wno-padded -Wno-weak-vtables -Wno-c++98-compat-pedantic -Wno-deprecated -Wno-documentation-unknown-command -Wno-global-constructors -Wno-exit-time-destructors -Wno-sign-conversion -Wno-conversion -Wno-float-equal -Wno-inconsistent-missing-destructor-override -Wno-unused-parameter -Wno-gnu-zero-variadic-macro-arguments`, but to do so it may require https://github.com/emil-e/rapidcheck/pull/167 first.