### PR TITLE
Newer GCC (6+) complain about possibly uninitialized variable in release mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,24 @@ branches:
 
 matrix:
   include:
+    # GCC 6
+    - addons: &gcc6
+        apt:
+          sources:
+            - george-edison55-precise-backports
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake
+            - cmake-data
+            - ninja-build
+            - g++-6
+      compiler: gcc
+      env: COMPILER_VERSION=6 BUILD_TYPE=Release
+
+    - addons: *gcc6
+      compiler: gcc
+      env: COMPILER_VERSION=6 BUILD_TYPE=Debug
+
     # GCC 4.9
     - addons: &gcc49
         apt:


### PR DESCRIPTION
See attached Travis' logs that reproduce the issue.

The issue can be reproduced locally with `-O3` and compiling `IntegrationTests.cpp` with default options: `-Wall -Werror -Wno-missing-braces -std=c++11`