### PR TITLE
Update boost to 1.65.1

### DIFF
--- a/ext/get_boost.sh
+++ b/ext/get_boost.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-curl -s -L -o boost_1_59_0.tar.bz2 "http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.59.0%2Fboost_1_59_0.tar.bz2%2Fdownload&ts=1441133751&use_mirror=skylink"
-tar xjfp boost_1_59_0.tar.bz2
-mv boost_1_59_0 boost
-rm boost_1_59_0.tar.bz2
+curl -s -L -o boost_1_65_1.tar.bz2 https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+tar xjfp boost_1_65_1.tar.bz2
+mv boost_1_65_1 boost
+rm boost_1_65_1.tar.bz2


### PR DESCRIPTION
This fixes one issue about invalid use of placement new: https://lists.boost.org/Archives/boost/2016/04/228755.php https://github.com/boostorg/function/pull/9