### PR TITLE
chore: Explicitly specify namespace

### DIFF
--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -5,12 +5,13 @@
 
 #define RC_INTERNAL_CONDITIONAL_RESULT(                                        \
     ResultType, expression, invert, name, ...)                                 \
-  doAssert(RC_INTERNAL_CAPTURE(expression),                                    \
-           (invert),                                                           \
-           ::rc::detail::CaseResult::Type::ResultType,                         \
-           __FILE__,                                                           \
-           __LINE__,                                                           \
-           name "(" #expression ")")
+  ::rc::detail::doAssert(RC_INTERNAL_CAPTURE(expression),                      \
+                         (invert),                                             \
+                         ::rc::detail::CaseResult::Type::ResultType,           \
+                         __FILE__,                                             \
+                         __LINE__,                                             \
+                         name "(" #expression ")")
+
 
 #define RC_INTERNAL_STRINGIFY(x) #x
 


### PR DESCRIPTION
To help CLion's syntax checker.