### PR TITLE
Use system time as the random seed when compiled with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,15 @@ endif()
 
 target_include_directories(rapidcheck PUBLIC include)
 
+
+# On Windows under MinGW, random_device provides no entropy,
+# so it will always return the same value.
+# Seed using system time instead.
+# See: https://stackoverflow.com/questions/18880654/why-do-i-get-the-same-sequence-for-every-run-with-stdrandom-device-with-mingw
+if(MINGW)
+  target_compile_definitions(rapidcheck PRIVATE RC_SEED_SYSTEM_TIME)
+endif()
+
 add_subdirectory(ext)
 
 if (RC_ENABLE_TESTS)

--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -1,6 +1,12 @@
 #include "rapidcheck/detail/Configuration.h"
 
+
+#ifdef RC_SEED_SYSTEM_TIME
+#include <ctime>
+#else
 #include <random>
+#endif
+
 #include <cstdlib>
 #include <sstream>
 #include <iostream>
@@ -197,9 +203,15 @@ namespace {
 
 Configuration loadConfiguration() {
   Configuration config;
+
   // Default to random seed
+#ifdef RC_SEED_SYSTEM_TIME
+  // See comment in CMakeLists.txt where RC_SEED_SYSTEM_TIME is set for the rationale here
+  config.testParams.seed = static_cast<uint64_t>(std::time(nullptr));
+#else
   std::random_device device;
   config.testParams.seed = (static_cast<uint64_t>(device()) << 32) | device();
+#endif
 
   const auto params = getEnvValue("RC_PARAMS");
   if (params) {


### PR DESCRIPTION
I have noticed that when compiling and running tests that use RapidCheck on Windows with MSYS2 and MinGW, the same random seed is used every time. This seems to be a flaw in the underlying stdlib, `std::random_device` always returns the same value, making it useless as a seed.

I have implemented a workaround to instead use the system time as the random seed when compiled with MinGW.

I found this relevant post on StackOverflow: https://stackoverflow.com/questions/18880654/why-do-i-get-the-same-sequence-for-every-run-with-stdrandom-device-with-mingw
