### PR TITLE
build shared library, allow system install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_testing()
 
 option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)
 option(RC_ENABLE_EXAMPLES "Build RapidCheck examples" OFF)
+option(RC_SHARED_LIBRARY "Build RapidCheck as a shared library" OFF)
 
 if(MSVC)
   # /bigobj - some object files become very large so we need this
@@ -23,7 +24,13 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-missing-braces -std=c++11")
 endif()
 
-add_library(rapidcheck
+if(RC_SHARED_LIBRARY)
+  set(LIBRARY_TYPE "SHARED")
+else()
+  set(LIBRARY_TYPE "STATIC")
+endif()
+
+add_library(rapidcheck ${LIBRARY_TYPE}
   src/BeforeMinimalTestCase.cpp
   src/Check.cpp
   src/Classify.cpp
@@ -82,3 +89,5 @@ if (RC_ENABLE_EXAMPLES)
 endif()
 
 add_subdirectory(extras)
+
+install(TARGETS rapidcheck DESTINATION /usr/lib)


### PR DESCRIPTION
These changes will

1. Address Issue #182 by allowing the user to install the library.

2. Allow the user to create a shared library instead of a static library as follows:

    cmake -DRC_SHARED_LIBRARY=ON .

You may prefer some other way of doing this, so feel free to reject this pull request.