### PR TITLE
Add generator for std::variant

### DIFF
--- a/doc/generators.md
+++ b/doc/generators.md
@@ -48,6 +48,7 @@ Out of the box, RapidCheck has support for generating arbitrary values of the fo
 - `std::pair<T1, T2>`
 - `std::chrono::duration<Rep, Period>`
 - `std::chrono::time_point<Clock, Duration>`
+- `std::variant<Ts...>`
 - `rc::Maybe<T>`
 
 The caveat is, of course, that for template types, RapidCheck must know how to generate the template arguments.

--- a/include/rapidcheck.h
+++ b/include/rapidcheck.h
@@ -29,6 +29,7 @@
 #include "rapidcheck/gen/Text.h"
 #include "rapidcheck/gen/Transform.h"
 #include "rapidcheck/gen/Tuple.h"
+#include "rapidcheck/gen/Variant.h"
 
 #include "rapidcheck/Assertions.h"
 #include "rapidcheck/Check.h"

--- a/include/rapidcheck/gen/Variant.h
+++ b/include/rapidcheck/gen/Variant.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <variant>
+
+namespace rc {
+namespace gen {
+
+} // namespace gen
+} // namespace rc
+
+#include "Variant.hpp"

--- a/include/rapidcheck/gen/Variant.hpp
+++ b/include/rapidcheck/gen/Variant.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace rc {
+namespace gen {
+namespace detail {
+
+template<>
+struct DefaultArbitrary<std::monostate> {
+  static Gen<std::monostate> arbitrary() {
+    return gen::element(std::monostate());
+  }
+};
+
+template <typename T, typename... Ts>
+struct DefaultArbitrary<std::variant<T, Ts...>> {
+  static Gen<std::variant<T, Ts...>> arbitrary() {
+    return gen::oneOf(
+      gen::cast<std::variant<T, Ts...>>(gen::arbitrary<T>()),
+      gen::cast<std::variant<T, Ts...>>(gen::arbitrary<Ts>())...);
+  }
+};
+
+} // namespace detail
+} // namespace gen
+} // namespace rc


### PR DESCRIPTION
This patch adds a generator for `std::variant`. The implementation is as for `rc::Variant`, with the addition of a generator for `std::monostate`.

It should probably:
  - [ ] Do a feature check for `<variant>` or for C++17
  - [ ] Include tests (derived from `test/detail/Variant.cpp`?)