### PR TITLE
fix build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ if(MSVC)
     CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-missing-braces -std=c++11")
+  if(APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  endif()
 endif()
 
 add_library(rapidcheck


### PR DESCRIPTION
Without the `-stdlib=libc++` option the build fails with:

    [  5%] Building CXX object CMakeFiles/rapidcheck.dir/src/Check.cpp.o
    In file included from /Users/yairchu/dev/rapidcheck/src/Check.cpp:1:
    In file included from /Users/yairchu/dev/rapidcheck/include/rapidcheck/Check.h:21:
    In file included from /Users/yairchu/dev/rapidcheck/include/rapidcheck/Check.hpp:5:
    /Users/yairchu/dev/rapidcheck/include/rapidcheck/detail/Configuration.h:3:10: fatal error: 'cstdint' file not found