### PR TITLE
Fix warnings when compiling with clang 8

### DIFF
--- a/test/GenTests.cpp
+++ b/test/GenTests.cpp
@@ -176,7 +176,8 @@ TEST_CASE("Gen") {
     SECTION("self assignment leaves value unchanged") {
       const auto shrinkable = shrinkable::just(1337);
       Gen<int> gen([=](const Random &random, int size) { return shrinkable; });
-      gen = gen;
+      auto &ref = gen;
+      gen = ref;
       REQUIRE(gen(Random(), 0) == shrinkable);
     }
   }

--- a/test/MaybeTests.cpp
+++ b/test/MaybeTests.cpp
@@ -187,7 +187,8 @@ TEST_CASE("Maybe") {
       }
 
       SECTION("self assign leaves self unchanged") {
-        lhs = lhs;
+        auto &ref = lhs;
+        lhs = ref;
         REQUIRE_FALSE(lhs);
       }
     }
@@ -227,7 +228,8 @@ TEST_CASE("Maybe") {
       }
 
       SECTION("self assign leaves self unchanged") {
-        lhs = lhs;
+        auto &ref = lhs;
+        lhs = ref;
         REQUIRE(lhs->id == "bar");
       }
     }

--- a/test/SeqTests.cpp
+++ b/test/SeqTests.cpp
@@ -48,7 +48,8 @@ TEST_CASE("Seq") {
   SECTION("self assignment leaves value unchanged") {
     const auto seq = seq::just(1, 2);
     auto x = seq;
-    x = x;
+    auto &ref = x;
+    x = ref;
 
     REQUIRE(x == seq);
   }

--- a/test/ShrinkableTests.cpp
+++ b/test/ShrinkableTests.cpp
@@ -94,7 +94,8 @@ TEST_CASE("Shrinkable") {
     const auto shrinkable =
         shrinkable::just(13, seq::just(shrinkable::just(37)));
     auto x = shrinkable;
-    x = x;
+    auto &ref = x;
+    x = ref;
     REQUIRE(x == shrinkable);
   }
 

--- a/test/detail/VariantTests.cpp
+++ b/test/detail/VariantTests.cpp
@@ -159,7 +159,8 @@ TEST_CASE("Variant") {
 
       SECTION("self assignment leaves value unchanged") {
         ABC v(Logger("foo"));
-        v = v;
+        auto &ref = v;
+        v = ref;
         REQUIRE(v.is<Logger>());
         REQUIRE(v.get<Logger>().id == "foo");
       }

--- a/test/state/gen/ExecCommandsTests.cpp
+++ b/test/state/gen/ExecCommandsTests.cpp
@@ -44,10 +44,10 @@ struct GeneratesOnConstrution : public IntVecCmd {
 } // namespace
 
 // Test is for deprecated function, don't warn since we're just testing.
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif // __GNUC__
+#endif // defined(__GNUC__) || defined(__clang__)
 
 TEST_CASE("state::gen::execOneOf") {
   prop("returns one of the commands",
@@ -91,9 +91,9 @@ TEST_CASE("state::gen::execOneOf") {
        });
 }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
-#endif // __GNUC__
+#endif // defined(__GNUC__) || defined(__clang__)
 
 TEST_CASE("state::gen::execOneOfWithArgs") {
   prop("returns one of the commands",


### PR DESCRIPTION
Because RapidCheck builds with the werror flag, warnings appearing with newer compilers might cause some issues. It is possible to hit this when building with clang 8. The error -Wself-assign-overloaded is
reported in some of the test cases for the project, which actually  test for self-assignment. To continue building with no warnings, we can add a small indirection where we just take a local reference and perform the self-assignment using it. This reduces the need to use pragmas or the need to modify the with warning flags for the test files.

Additionally, a deprecation warning is reported in ExecCommandsTests.cpp because a pragma that disables the warning locally is used only when compiling with gcc. That check should be extended to also handle clang since the same code works for clang as well.