### PR TITLE
Improve CMake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,10 @@ target_include_directories(rapidcheck PUBLIC
 
 include(GNUInstallDirs)
 install(TARGETS rapidcheck EXPORT rapidcheckConfig
-    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})  # This is for Windows
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # On Windows under MinGW, random_device provides no entropy,
@@ -107,4 +108,4 @@ add_subdirectory(extras)
 
 # Install the export file specifying all the targets for RapidCheck
 install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
-export(TARGETS rapidcheck FILE rapidcheckConfig.cmake)
+export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 11)
 
+option(RC_BUILD_SHARED_LIB "Build RapidCheck as a shared library" OFF)
 option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)
 option(RC_ENABLE_EXAMPLES "Build RapidCheck examples" OFF)
 
@@ -26,7 +27,13 @@ else()
   endif()
 endif()
 
-add_library(rapidcheck
+if(RC_BUILD_SHARED_LIB)
+  set(RC_SHARED_OR_STATIC "SHARED")
+else()
+  set(RC_SHARED_OR_STATIC "STATIC")
+endif()
+
+add_library(rapidcheck ${RC_SHARED_OR_STATIC}
   src/BeforeMinimalTestCase.cpp
   src/Check.cpp
   src/Classify.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD 11)
 
-enable_testing()
-
 option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)
 option(RC_ENABLE_EXAMPLES "Build RapidCheck examples" OFF)
 
@@ -74,11 +72,9 @@ else()
     APPEND_STRING PROPERTY COMPILE_FLAGS " -O3")
 endif()
 
-
-
 target_include_directories(rapidcheck PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-    $<INSTALL_INTERFACE:include/rapidcheck>  # <prefix>/include/rapidcheck
+    $<INSTALL_INTERFACE:include>  # <prefix>/include
 )
 
 include(GNUInstallDirs)
@@ -87,12 +83,6 @@ install(TARGETS rapidcheck EXPORT rapidcheckConfig
     LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})  # This is for Windows
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
-
-export(TARGETS rapidcheck FILE rapidcheckConfig.cmake)
-
-
 
 # On Windows under MinGW, random_device provides no entropy,
 # so it will always return the same value.
@@ -104,12 +94,17 @@ endif()
 
 add_subdirectory(ext)
 
-if (RC_ENABLE_TESTS)
+if(RC_ENABLE_TESTS)
+  enable_testing()
   add_subdirectory(test)
 endif()
 
-if (RC_ENABLE_EXAMPLES)
+if(RC_ENABLE_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
 add_subdirectory(extras)
+
+# Install the export file specifying all the targets for RapidCheck
+install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
+export(TARGETS rapidcheck FILE rapidcheckConfig.cmake)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -1,24 +1,28 @@
+# Since 
+option(RC_INSTALL_ALL_EXTRAS "Add all possible integrations without
+  requiring the initialization of all the submodules in ext." OFF)
+
 option(RC_ENABLE_CATCH "Build Catch.hpp support" OFF)
-if (RC_ENABLE_CATCH OR RC_ENABLE_TESTS)
+if (RC_ENABLE_CATCH OR RC_ENABLE_TESTS OR RC_INSTALL_ALL_EXTRAS)
   add_subdirectory(catch)
 endif()
 
 option(RC_ENABLE_GMOCK "Build Google Mock integration" OFF)
-if (RC_ENABLE_GMOCK)
+if (RC_ENABLE_GMOCK OR RC_INSTALL_ALL_EXTRAS)
   add_subdirectory(gmock)
 endif()
 
 option(RC_ENABLE_GTEST "Build Google Test integration" OFF)
-if (RC_ENABLE_GTEST)
+if (RC_ENABLE_GTEST OR RC_INSTALL_ALL_EXTRAS)
   add_subdirectory(gtest)
 endif()
 
 option(RC_ENABLE_BOOST "Build Boost support" OFF)
-if (RC_ENABLE_BOOST)
+if (RC_ENABLE_BOOST OR RC_INSTALL_ALL_EXTRAS)
   add_subdirectory(boost)
 endif()
 
 option(RC_ENABLE_BOOST_TEST "Build Boost Test support" OFF)
-if (RC_ENABLE_BOOST_TEST)
+if (RC_ENABLE_BOOST_TEST OR RC_INSTALL_ALL_EXTRAS)
   add_subdirectory(boost_test)
 endif()

--- a/extras/boost/CMakeLists.txt
+++ b/extras/boost/CMakeLists.txt
@@ -1,6 +1,14 @@
 add_library(rapidcheck_boost INTERFACE)
 target_link_libraries(rapidcheck_boost INTERFACE rapidcheck)
-target_include_directories(rapidcheck_boost INTERFACE include)
+target_include_directories(rapidcheck_boost INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# An INTERFACE library does not need to install anything but its headers
+# and information on its targets.
+install(TARGETS rapidcheck_boost EXPORT rapidcheckConfig)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if (RC_ENABLE_TESTS)
   add_subdirectory(test)

--- a/extras/boost_test/CMakeLists.txt
+++ b/extras/boost_test/CMakeLists.txt
@@ -1,3 +1,11 @@
 add_library(rapidcheck_boost_test INTERFACE)
 target_link_libraries(rapidcheck_boost_test INTERFACE rapidcheck)
-target_include_directories(rapidcheck_boost_test INTERFACE include)
+target_include_directories(rapidcheck_boost_test INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# An INTERFACE library does not need to install anything but its headers
+# and information on its targets.
+install(TARGETS rapidcheck_boost_test EXPORT rapidcheckConfig)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/extras/catch/CMakeLists.txt
+++ b/extras/catch/CMakeLists.txt
@@ -1,3 +1,11 @@
 add_library(rapidcheck_catch INTERFACE)
 target_link_libraries(rapidcheck_catch INTERFACE rapidcheck)
-target_include_directories(rapidcheck_catch INTERFACE include)
+target_include_directories(rapidcheck_catch INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# An INTERFACE library does not need to install anything but its headers
+# and information on its targets.
+install(TARGETS rapidcheck_catch EXPORT rapidcheckConfig)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/extras/gmock/CMakeLists.txt
+++ b/extras/gmock/CMakeLists.txt
@@ -1,6 +1,14 @@
 add_library(rapidcheck_gmock INTERFACE)
 target_link_libraries(rapidcheck_gmock INTERFACE rapidcheck)
-target_include_directories(rapidcheck_gmock INTERFACE include)
+target_include_directories(rapidcheck_gmock INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# An INTERFACE library does not need to install anything but its headers
+# and information on its targets.
+install(TARGETS rapidcheck_gmock EXPORT rapidcheckConfig)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if (RC_ENABLE_TESTS)
   add_subdirectory(test)

--- a/extras/gtest/CMakeLists.txt
+++ b/extras/gtest/CMakeLists.txt
@@ -1,3 +1,11 @@
 add_library(rapidcheck_gtest INTERFACE)
 target_link_libraries(rapidcheck_gtest INTERFACE rapidcheck)
-target_include_directories(rapidcheck_gtest INTERFACE include)
+target_include_directories(rapidcheck_gtest INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# An INTERFACE library does not need to install anything but its headers
+# and information on its targets.
+install(TARGETS rapidcheck_gtest EXPORT rapidcheckConfig)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
There are a couple of improvements made to the CMake files in order to make the export and import of the CMake targets more useful and, in general, make the library be as easily consumed as an external dependency as it is including it as sub-project - if RapidCheck is to be used in different package managers, this is essential.

The changes were motivated by the desire to add a port of RapidCheck to VCPKG (a C++ based package manager). Here is a description of the major changes:

- The install interface directories were not properly set, leading to the need to use "../rapidcheck.h" to access the primary library header. The fix for this is trivial.
- All the extra integration header-only libraries are now properly installed and exported so that these integration can now be used from an installed bundle of the library.
- The _RC_INSTALL_ALL_EXTRAS_ CMake option is added to allow for an easier installation of the integrations without the need to require the inclusion and set up of the submodule projects in _ext_. This can be improved but it should be fine for an initial version.
- The _RC_BUILD_SHARED_LIB_ is added to have finer control over the type of the RapidCheck library. This is done as to have greater control over what kind of library VCPKG (and possibly other package managers) can build. It does not make much sense to build as a shared library for now (as no symbols are exported explicitly, which is an issue on Windows) but it would be useful to have the infrastructure in place.