### PR TITLE
Update Catch to v2.4.2

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,6 +1,5 @@
 if (RC_ENABLE_TESTS OR RC_ENABLE_CATCH)
-  add_library(catch INTERFACE)
-  target_include_directories(catch INTERFACE catch/include)
+  add_subdirectory(catch)
 endif()
 
 if ((RC_ENABLE_GMOCK OR RC_ENABLE_GTEST) AND RC_ENABLE_TESTS)

--- a/extras/boost/test/CMakeLists.txt
+++ b/extras/boost/test/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(rapidcheck_boost_tests
   rapidcheck_boost
   rapidcheck_catch
   rapidcheck_test_utils
-  catch)
+  Catch2::Catch2)
 
 add_test(
   NAME rapidcheck_boost_tests

--- a/extras/boost/test/OptionalTests.cpp
+++ b/extras/boost/test/OptionalTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/boost.h>
 

--- a/extras/boost/test/main.cpp
+++ b/extras/boost/test/main.cpp
@@ -12,4 +12,4 @@ inline bool uncaught_exception() noexcept(true) {
 #endif
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>

--- a/extras/catch/include/rapidcheck/catch.h
+++ b/extras/catch/include/rapidcheck/catch.h
@@ -3,11 +3,11 @@
 #include <sstream>
 
 #include <rapidcheck.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 namespace rc {
 
-/// For use with `catch.hpp`. Use this function wherever you would use a
+/// For use with `catch2/catch.hpp`. Use this function wherever you would use a
 /// `SECTION` for convenient checking of properties.
 ///
 /// @param description  A description of the property.

--- a/extras/gmock/test/CMakeLists.txt
+++ b/extras/gmock/test/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(rapidcheck_gmock_tests main.cpp)
 target_link_libraries(rapidcheck_gmock_tests
   rapidcheck_gmock
   rapidcheck_catch
-  catch
+  Catch2::Catch2
   gmock)
 target_include_directories(rapidcheck_gmock_tests PRIVATE 
     ${CMAKE_SOURCE_DIR}/ext/googletest/googletest/include

--- a/extras/gmock/test/main.cpp
+++ b/extras/gmock/test/main.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_RUNNER
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <gmock/gmock.h>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/gmock.h>

--- a/test/AssertionsTests.cpp
+++ b/test/AssertionsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <algorithm>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ add_executable(rapidcheck_tests
 
 target_link_libraries(rapidcheck_tests
   rapidcheck
-  catch
+  Catch2::Catch2
   rapidcheck_catch
   rapidcheck_test_utils)
 target_include_directories(rapidcheck_tests PRIVATE

--- a/test/CheckTests.cpp
+++ b/test/CheckTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/TestListenerAdapter.h"

--- a/test/ClassifyTests.cpp
+++ b/test/ClassifyTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 using namespace rc;

--- a/test/GenTests.cpp
+++ b/test/GenTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/Gen.h"

--- a/test/LogTests.cpp
+++ b/test/LogTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 using namespace rc;

--- a/test/MaybeTests.cpp
+++ b/test/MaybeTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/Maybe.h"

--- a/test/RandomTests.cpp
+++ b/test/RandomTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <numeric>

--- a/test/SeqTests.cpp
+++ b/test/SeqTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/Seq.h"

--- a/test/ShowTests.cpp
+++ b/test/ShowTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/Box.h"

--- a/test/ShrinkableTests.cpp
+++ b/test/ShrinkableTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/Shrinkable.h"

--- a/test/detail/AnyTests.cpp
+++ b/test/detail/AnyTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "rapidcheck/detail/Any.h"
 

--- a/test/detail/ApplyTupleTests.cpp
+++ b/test/detail/ApplyTupleTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/ApplyTuple.h"

--- a/test/detail/Base64Tests.cpp
+++ b/test/detail/Base64Tests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "detail/Base64.h"

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <numeric>

--- a/test/detail/CaptureTests.cpp
+++ b/test/detail/CaptureTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Capture.h"

--- a/test/detail/ConfigurationTests.cpp
+++ b/test/detail/ConfigurationTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/TemplateProps.h"

--- a/test/detail/DefaultTestListenerTests.cpp
+++ b/test/detail/DefaultTestListenerTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "detail/DefaultTestListener.h"
 

--- a/test/detail/FrequencyMapTests.cpp
+++ b/test/detail/FrequencyMapTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <numeric>

--- a/test/detail/ImplicitParamTests.cpp
+++ b/test/detail/ImplicitParamTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/detail/LogTestListenerTests.cpp
+++ b/test/detail/LogTestListenerTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "detail/LogTestListener.h"
 

--- a/test/detail/MapParserTests.cpp
+++ b/test/detail/MapParserTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "detail/MapParser.h"

--- a/test/detail/MulticastTestListenerTests.cpp
+++ b/test/detail/MulticastTestListenerTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "detail/MulticastTestListener.h"

--- a/test/detail/PropertyTests.cpp
+++ b/test/detail/PropertyTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Property.h"

--- a/test/detail/ReproduceListenerTests.cpp
+++ b/test/detail/ReproduceListenerTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "detail/ReproduceListener.h"

--- a/test/detail/ResultsTests.cpp
+++ b/test/detail/ResultsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <sstream>

--- a/test/detail/SerializationTests/CompactIntegers.cpp
+++ b/test/detail/SerializationTests/CompactIntegers.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Serialization.h"

--- a/test/detail/SerializationTests/CompactRanges.cpp
+++ b/test/detail/SerializationTests/CompactRanges.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Serialization.h"

--- a/test/detail/SerializationTests/Integers.cpp
+++ b/test/detail/SerializationTests/Integers.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Serialization.h"

--- a/test/detail/SerializationTests/Misc.cpp
+++ b/test/detail/SerializationTests/Misc.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Serialization.h"

--- a/test/detail/ShowTypeTests.cpp
+++ b/test/detail/ShowTypeTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "rapidcheck/detail/ShowType.h"
 

--- a/test/detail/StringSerializationTests.cpp
+++ b/test/detail/StringSerializationTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "detail/StringSerialization.h"

--- a/test/detail/TestMetadataTests.cpp
+++ b/test/detail/TestMetadataTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/TestMetadata.h"

--- a/test/detail/TestParamsTests.cpp
+++ b/test/detail/TestParamsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/detail/Configuration.h"

--- a/test/detail/TestingTests.cpp
+++ b/test/detail/TestingTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <algorithm>

--- a/test/detail/VariantTests.cpp
+++ b/test/detail/VariantTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "util/Util.h"
 #include "util/Logger.h"

--- a/test/fn/CommonTests.cpp
+++ b/test/fn/CommonTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/fn/Common.h"

--- a/test/gen/BuildTests.cpp
+++ b/test/gen/BuildTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/GenUtils.h"

--- a/test/gen/ChronoTests.cpp
+++ b/test/gen/ChronoTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Chrono.h"

--- a/test/gen/ContainerTests/Fixed.cpp
+++ b/test/gen/ContainerTests/Fixed.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "Common.h"

--- a/test/gen/ContainerTests/NonFixed.cpp
+++ b/test/gen/ContainerTests/NonFixed.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/Predictable.h"

--- a/test/gen/ContainerTests/Unique.cpp
+++ b/test/gen/ContainerTests/Unique.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "Common.h"

--- a/test/gen/CreateTests.cpp
+++ b/test/gen/CreateTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Create.h"

--- a/test/gen/ExecTests.cpp
+++ b/test/gen/ExecTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Exec.h"

--- a/test/gen/MaybeTests.cpp
+++ b/test/gen/MaybeTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/GenUtils.h"

--- a/test/gen/NumericTests.cpp
+++ b/test/gen/NumericTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <numeric>

--- a/test/gen/PredicateTests.cpp
+++ b/test/gen/PredicateTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/GenUtils.h"

--- a/test/gen/SelectTests.cpp
+++ b/test/gen/SelectTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Create.h"

--- a/test/gen/TextTests.cpp
+++ b/test/gen/TextTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Text.h"

--- a/test/gen/TransformTests.cpp
+++ b/test/gen/TransformTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/Transform.h"

--- a/test/gen/TupleTests.cpp
+++ b/test/gen/TupleTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/ArbitraryRandom.h"

--- a/test/gen/detail/ExecRawTests.cpp
+++ b/test/gen/detail/ExecRawTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <algorithm>

--- a/test/gen/detail/RecipeTests.cpp
+++ b/test/gen/detail/RecipeTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/gen/detail/Recipe.h"

--- a/test/gen/detail/ScaleIntegerTests.cpp
+++ b/test/gen/detail/ScaleIntegerTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 using namespace rc;

--- a/test/gen/detail/ShrinkValueIteratorTests.cpp
+++ b/test/gen/detail/ShrinkValueIteratorTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <algorithm>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,4 +12,4 @@ inline bool uncaught_exception() noexcept(true) {
 #endif
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>

--- a/test/seq/CreateTests.cpp
+++ b/test/seq/CreateTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/seq/Create.h"

--- a/test/seq/OperationsTests.cpp
+++ b/test/seq/OperationsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <algorithm>

--- a/test/seq/SeqIteratorTests.cpp
+++ b/test/seq/SeqIteratorTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "util/Generators.h"

--- a/test/seq/TransformTests.cpp
+++ b/test/seq/TransformTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/seq/Transform.h"

--- a/test/shrink/ShrinkTests.cpp
+++ b/test/shrink/ShrinkTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include <cctype>

--- a/test/shrinkable/CreateTests.cpp
+++ b/test/shrinkable/CreateTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/shrinkable/Create.h"

--- a/test/shrinkable/OperationsTests.cpp
+++ b/test/shrinkable/OperationsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/shrinkable/Operations.h"

--- a/test/shrinkable/TransformTests.cpp
+++ b/test/shrinkable/TransformTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 
 #include "rapidcheck/shrinkable/Transform.h"

--- a/test/state/CommandTests.cpp
+++ b/test/state/CommandTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/state/CommandsTests.cpp
+++ b/test/state/CommandsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/state/IntegrationTests.cpp
+++ b/test/state/IntegrationTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/state/StateTests.cpp
+++ b/test/state/StateTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/state/gen/CommandsTests.cpp
+++ b/test/state/gen/CommandsTests.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <rapidcheck/catch.h>
 #include <rapidcheck/state.h>
 

--- a/test/util/Logger.h
+++ b/test/util/Logger.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <algorithm>
 


### PR DESCRIPTION
GCC warns about catching exceptions by value, which is fixed in newer
Catch release. v2.4.2 is the newest release to date. Additionally,
update to Catch2's newer structure and use the provided cmake project.