### PR TITLE
Add fixed-count overloads for gen::unique(By)

### DIFF
--- a/doc/generators_ref.md
+++ b/doc/generators_ref.md
@@ -264,6 +264,10 @@ Generates a container of unique `T`. The `Container` type parameter must be spec
 const auto uniqueInts = gen::unique<std::vector<int>>(gen::arbitrary<int>());
 ```
 
+### `Gen<Container> unique(std::size_t count, Gen<T> gen)`
+
+Like `unique(Gen<T> gen)` but generates containers of a fixed size `count.`
+
 ### `Gen<Container> uniqueBy(Gen<T> gen, F f)`
 
 Generates a container of `T` such that for every element `e` in the container, `f(e)` is unique. The `Container` type parameter must be specified explicitly.
@@ -276,6 +280,10 @@ const auto uniquePeople = gen::uniqueBy<std::vector<Person>>(
       return std::make_pair(p.firstName, p.lastName);
     });
 ```
+
+### `Gen<Container> uniqueBy(std::size_t count, Gen<T> gen, F f)`
+
+Like `uniqueBy(Gen<T> gen, F f)` but generates containers of a fixed size `count.`
 
 ## Picking
 

--- a/doc/generators_ref.md
+++ b/doc/generators_ref.md
@@ -253,7 +253,7 @@ const auto smallInts = *gen::container<std::vector<int>>(gen::inRange(0, 100));
 
 ### `Gen<Container> container(std::size_t count, Gen<Ts>... gens)`
 
-Like `container(Gen<Ts>... gens)` but generates containers of a fixed size `count.`
+Like `container(Gen<Ts>... gens)` but generates containers of a fixed size `count`.
 
 ### `Gen<Container> unique(Gen<T> gen)`
 
@@ -266,7 +266,7 @@ const auto uniqueInts = gen::unique<std::vector<int>>(gen::arbitrary<int>());
 
 ### `Gen<Container> unique(std::size_t count, Gen<T> gen)`
 
-Like `unique(Gen<T> gen)` but generates containers of a fixed size `count.`
+Like `unique(Gen<T> gen)` but generates containers of a fixed size `count`.
 
 ### `Gen<Container> uniqueBy(Gen<T> gen, F f)`
 
@@ -283,7 +283,7 @@ const auto uniquePeople = gen::uniqueBy<std::vector<Person>>(
 
 ### `Gen<Container> uniqueBy(std::size_t count, Gen<T> gen, F f)`
 
-Like `uniqueBy(Gen<T> gen, F f)` but generates containers of a fixed size `count.`
+Like `uniqueBy(Gen<T> gen, F f)` but generates containers of a fixed size `count`.
 
 ## Picking
 

--- a/include/rapidcheck/gen/Container.hpp
+++ b/include/rapidcheck/gen/Container.hpp
@@ -519,5 +519,22 @@ Gen<Container> uniqueBy(Gen<T> gen, F &&f) {
   };
 }
 
+template <typename Container, typename T, typename F>
+Gen<Container> uniqueBy(std::size_t count, Gen<T> gen, F &&f) {
+  using Strategy = detail::UniqueContainerStrategy<Decay<F>>;
+  detail::ContainerHelper<Container, Strategy> helper(
+      Strategy(std::forward<F>(f)));
+
+  return [=](const Random &random, int size) {
+    return helper.generate(count, random, size, gen);
+  };
+}
+
+template <typename Container, typename T>
+Gen<Container> unique(std::size_t count, Gen<T> gen) {
+  return gen::uniqueBy<Container>(count, std::move(gen),
+                                  [](const T &x) -> const T & { return x; });
+}
+
 } // namespace gen
 } // namespace rc


### PR DESCRIPTION
I've run into the need to generate fixed-size containers with unique elements (for generating valid CSR matrices); this PR adds the functionality into rapidcheck as additional overloads for `gen::unique` and `gen::uniqueBy`, similar to what's already there for `gen::container`.