### PR TITLE
Add missing includes and fix signed/unsigned comparison

### DIFF
--- a/include/rapidcheck/Random.h
+++ b/include/rapidcheck/Random.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <array>
 #include <limits>
+#include <iosfwd>
+#include <functional>
 
 namespace rc {
 

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -60,7 +60,8 @@ T BitStream<Source>::next(int nbits, std::false_type) {
     // To avoid right-shifting data beyond the width of the given type (which is
     // undefined behavior, because of course it is) only perform this shift-
     // assignment if we have room.
-    if (static_cast<SourceType>(n) < numBits<SourceType>()) {
+    if (static_cast<SourceType>(n) <
+        static_cast<SourceType>(numBits<SourceType>())) {
       m_bits >>= static_cast<SourceType>(n);
     }
     m_numBits -= n;


### PR DESCRIPTION
Random was using `std::ostream` without `<iosfwd>` and `std::hash`
without `<functional>`. In BitStream.hpp, if `SourceType` was unsigned
then the comparison to `numBits` (which returns `signed int`) would
cause a warning (which makes the code not compile because the
CMakeLists.txt sets -Werror on gcc/clang).

On a related note, `numBits` should probably be some unsigned type, and the `CMakeLists.txt` should _not_ set `-Werror` by default (otherwise the code will suddenly start failing to compile whenever you upgrade to a smarter compiler, which is all well and good if you're developing the library but it's a nightmare for package maintainers and consumers).