### PR TITLE
Fix conversion warnings where an implicit conversions may alter a value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(MSVC)
   string(REGEX REPLACE "/RTC(su|[1su])" ""
     CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-missing-braces -Wno-unused-command-line-argument")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wconversion -Wno-missing-braces -Wno-unused-command-line-argument")
   if(APPLE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang)")
       # Workaround for legacy Apple environment (cf. https://stackoverflow.com/a/19774902/1682144)

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -56,7 +56,7 @@ T BitStream<Source>::next(int nbits, std::false_type) {
 
     const auto n = std::min(m_numBits, wantBits);
     const auto bits = m_bits & bitMask<SourceType>(n);
-    value |= (bits << (nbits - wantBits));
+    value |= static_cast<T>(bits << (nbits - wantBits));
     // To avoid right-shifting data beyond the width of the given type (which is
     // undefined behavior, because of course it is) only perform this shift-
     // assignment if we have room.
@@ -68,12 +68,12 @@ T BitStream<Source>::next(int nbits, std::false_type) {
   }
 
   if (std::is_signed<T>::value) {
-    T signBit = static_cast<T>(0x1) << static_cast<T>(nbits - 1);
+    T signBit = static_cast<T>(static_cast<T>(0x1) << static_cast<T>(nbits - 1));
     if ((value & signBit) != 0) {
       // For signed values, we use the last bit as the sign bit. Since this
       // was 1, mask away by setting all bits above this one to 1 to make it a
       // negative number in 2's complement
-      value |= ~bitMask<T>(nbits);
+      value = static_cast<T>(value | ~bitMask<T>(nbits));
     }
   }
 

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -106,9 +106,9 @@ constexpr T bitMask(int nbits) {
   // to an explicitly unsigned type before performing bitwise NOT and shift.
   // We're ensuring the target type is as big as unsigned, otherwise it will
   // be promoted to int before bitwise NOT, producing a negative value.
-  return nbits < std::numeric_limits<UT>::digits ?
+  return static_cast<T>(nbits < std::numeric_limits<UT>::digits ?
          ~T(~UTP(0) << nbits)                    :
-         ~T(0);
+         ~T(0));
 }
 
 // TODO separate into header and implementation file

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -43,7 +43,7 @@ Shrinkable<T> real(const Random &random, int size) {
       std::min(size, kNominalSize) / static_cast<double>(kNominalSize);
   const double a = static_cast<double>(stream.nextWithSize<int64_t>(size));
   const double b =
-      (stream.next<uint64_t>() * scale) / std::numeric_limits<uint64_t>::max();
+      (static_cast<double>(stream.next<uint64_t>()) * scale) / static_cast<double>(std::numeric_limits<uint64_t>::max());
   const T value = static_cast<T>(a + b);
   return shrinkable::shrinkRecur(value, &shrink::real<T>);
 }

--- a/include/rapidcheck/seq/Create.hpp
+++ b/include/rapidcheck/seq/Create.hpp
@@ -133,7 +133,7 @@ Seq<Decay<T>> repeat(T &&value) {
 
 template <typename T, typename... Ts>
 Seq<Decay<T>> just(T &&value, Ts &&... values) {
-  return makeSeq<detail::JustSeq<Decay<T>, sizeof...(Ts) + 1>>(
+  return makeSeq<detail::JustSeq<Decay<T>, static_cast<T>(sizeof...(Ts) + 1)>>(
       std::forward<T>(value), std::forward<Ts>(values)...);
 }
 

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -17,7 +17,7 @@ public:
 
   TowardsSeq(T value, T target)
       : m_value(value)
-      , m_diff((target < value) ? (value - target) : (target - value))
+      , m_diff(static_cast<UInt>((target < value) ? (value - target) : (target - value)))
       , m_down(target < value) {}
 
   Maybe<T> operator()() {
@@ -25,7 +25,7 @@ public:
       return Nothing;
     }
 
-    T ret = m_down ? (m_value - m_diff) : (m_value + m_diff);
+    T ret = static_cast<T>(m_down ? (m_value - m_diff) : (m_value + m_diff));
     m_diff /= 2;
     return ret;
   }


### PR DESCRIPTION
Some projects prefer to use -Wconversion to avoid certain mistakes. Rapidcheck had a few cases where explicit cast was needed to make it clear that the conversion deliberately done.