### PR TITLE
Allow configuration parameters to be read from file

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,7 @@
 # Configuration
 
 RapidCheck has several parameters that affect testing. These can be configured by setting the `RC_PARAMS` environment variable to a configuration string. The configuration string as the format `<key1>=<value1> <key2>=<value2> ...`. Values containing spaces can be quoted and backslash works as an escape character, just as you would expect.
+Another option is to write the configuration parameters in the same format as above in a file named `rc_params.txt`. The file can also contain multiple lines of `<key>=<value>` pairs. The configuration file must be located in the same directory where the program that uses rapidcheck is run.
 
 When RapidCheck is initialized, it prints the configuration that is used excluding parameters that are set to their default value. For example, when running a test without changing the defaults, the following could be printed:
 

--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdlib>
 #include <sstream>
+#include <fstream>
 #include <iostream>
 
 #include "MapParser.h"
@@ -213,7 +214,17 @@ Configuration loadConfiguration() {
   config.testParams.seed = (static_cast<uint64_t>(device()) << 32) | device();
 #endif
 
-  const auto params = getEnvValue("RC_PARAMS");
+  std::ifstream config_file("rc_config.txt");
+  std::string file_params;
+  if (config_file.good()) {
+    std::string line;
+    while (std::getline(config_file, line)) {
+      file_params += line + " ";
+    }
+  }
+
+  const auto params =
+      file_params.empty() ? getEnvValue("RC_PARAMS") : file_params;
   if (params) {
     try {
       config = configFromString(*params, config);


### PR DESCRIPTION
Some find environment variable unintuitive, so using a config file is more convenient. If no config file exists, RC_PARAMS environment variable can still be used for configuration. 