### PR TITLE
CMake: use `target_compile_definitions()` for the `RC_USE_RTTI` symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(MINGW)
 endif()
 
 if(RC_ENABLE_RTTI)
-  add_definitions(-DRC_USE_RTTI)
+  target_compile_definitions(rapidcheck PUBLIC RC_USE_RTTI)
 endif()
 
 add_subdirectory(ext)


### PR DESCRIPTION
This PR is intended to fix issue #247.

I am a bit unhappy about the fact that the compile definitions has to be declared as `PUBLIC` in CMake, meaning that it will propagate to all the projects that link to Rapidcheck. An alternative way to solve the bug would be to remove any appearance of the `RC_USE_RTTI` symbol from header files and move them to the implementation. If we do that, `RC_USE_RTTI` will become a `PRIVATE` symbol (like `RC_SEED_SYSTEM_TIME`).