### PR TITLE
Add Boost dependency to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ add_library(rapidcheck
   src/gen/detail/ScaleInteger.cpp
   )
 
+# TODO switch to Boost::headers when CMake 3.15 is deployed everywhere
+target_link_libraries(rapidcheck PUBLIC Boost::boost)
+
 # Random is used a LOT so it should preferrably be really fast.
 if(MSVC)
   set_property(SOURCE src/Random.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ else()
 endif()
 
 target_include_directories(rapidcheck PUBLIC include)
+target_include_directories(rapidcheck PRIVATE /usr/local/include)
 
 
 # On Windows under MinGW, random_device provides no entropy,

--- a/include/rapidcheck/detail/Cpp11.h
+++ b/include/rapidcheck/detail/Cpp11.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <boost/lexical_cast/try_lexical_convert.hpp>
+#include <boost/math/special_functions/trunc.hpp>
+
+#include <string>
+
+// The android gcc 4.9 toolchain does not support std::to_string. We replicate
+// that functionality using boost.
+
+namespace rc {
+template <typename T>
+std::string to_string(T value) {
+  ::std::string res;
+  return boost::conversion::try_lexical_convert(value, res) ? res : "";
+}
+
+template <typename T>
+T trunc(T value) {
+  return boost::math::trunc(value);
+}
+} // namespace rc

--- a/include/rapidcheck/gen/Container.hpp
+++ b/include/rapidcheck/gen/Container.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rapidcheck/detail/Cpp11.h"
 #include "rapidcheck/gen/Arbitrary.h"
 #include "rapidcheck/gen/Tuple.h"
 #include "rapidcheck/gen/detail/ShrinkValueIterator.h"
@@ -47,8 +48,7 @@ Shrinkables<T> generateShrinkables(const Random &random,
       if (tries >= 100) {
         // TODO magic constant!
         throw GenerationFailure("Gave up trying to generate " +
-                                std::to_string(count) +
-                                " values for container");
+                                rc::to_string(count) + " values for container");
       }
       currentSize++;
     }

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -3,6 +3,7 @@
 #include "rapidcheck/detail/BitStream.h"
 #include "rapidcheck/shrinkable/Create.h"
 #include "rapidcheck/shrink/Shrink.h"
+#include "rapidcheck/detail/Cpp11.h"
 #include "rapidcheck/gen/Transform.h"
 #include "rapidcheck/gen/detail/ScaleInteger.h"
 
@@ -92,8 +93,8 @@ Gen<T> inRange(T min, T max) {
   return [=](const Random &random, int size) {
     if (max <= min) {
       std::string msg;
-      msg += "Invalid range [" + std::to_string(min);
-      msg += ", " + std::to_string(max) + ")";
+      msg += "Invalid range [" + rc::to_string(min);
+      msg += ", " + rc::to_string(max) + ")";
       throw GenerationFailure(msg);
     }
 

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <locale>
 
+#include "rapidcheck/detail/Cpp11.h"
 #include "rapidcheck/seq/Transform.h"
 #include "rapidcheck/seq/Create.h"
 
@@ -174,7 +175,7 @@ Seq<T> real(T value) {
     shrinks.push_back(-value);
   }
 
-  T truncated = std::trunc(value);
+  T truncated = rc::trunc(value);
   if (std::abs(truncated) < std::abs(value)) {
     shrinks.push_back(truncated);
   }

--- a/src/detail/Assertions.cpp
+++ b/src/detail/Assertions.cpp
@@ -1,5 +1,7 @@
 #include "rapidcheck/Assertions.h"
 
+#include "rapidcheck/detail/Cpp11.h"
+
 namespace rc {
 namespace detail {
 
@@ -7,7 +9,7 @@ std::string makeMessage(const std::string &file,
                         int line,
                         const std::string &assertion,
                         const std::string &extra) {
-  auto msg = file + ":" + std::to_string(line) + ":\n" + assertion;
+  auto msg = file + ":" + rc::to_string(line) + ":\n" + assertion;
   if (!extra.empty()) {
     msg +=
         "\n"

--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -14,6 +14,7 @@
 #include "MapParser.h"
 #include "ParseException.h"
 #include "StringSerialization.h"
+#include "rapidcheck/detail/Cpp11.h"
 #include "rapidcheck/detail/Platform.h"
 
 namespace rc {
@@ -152,13 +153,13 @@ Configuration configFromMap(const std::map<std::string, std::string> &map,
 
 std::map<std::string, std::string> mapFromConfig(const Configuration &config) {
   return {
-      {"seed", std::to_string(config.testParams.seed)},
-      {"max_success", std::to_string(config.testParams.maxSuccess)},
-      {"max_size", std::to_string(config.testParams.maxSize)},
-      {"max_discard_ratio", std::to_string(config.testParams.maxDiscardRatio)},
+      {"seed", rc::to_string(config.testParams.seed)},
+      {"max_success", rc::to_string(config.testParams.maxSuccess)},
+      {"max_size", rc::to_string(config.testParams.maxSize)},
+      {"max_discard_ratio", rc::to_string(config.testParams.maxDiscardRatio)},
       {"noshrink", config.testParams.disableShrinking ? "1" : "0"},
-      {"verbose_progress", std::to_string(config.verboseProgress)},
-      {"verbose_shrinking", std::to_string(config.verboseShrinking)},
+      {"verbose_progress", rc::to_string(config.verboseProgress)},
+      {"verbose_shrinking", rc::to_string(config.verboseShrinking)},
       {"reproduce", reproduceMapToString(config.reproduce)}};
 }
 

--- a/src/detail/ParseException.cpp
+++ b/src/detail/ParseException.cpp
@@ -1,5 +1,7 @@
 #include "ParseException.h"
 
+#include "rapidcheck/detail/Cpp11.h"
+
 namespace rc {
 namespace detail {
 
@@ -7,7 +9,7 @@ ParseException::ParseException(std::string::size_type pos,
                                const std::string &msg)
     : m_pos(pos)
     , m_msg(msg)
-    , m_what("@" + std::to_string(m_pos) + ": " + msg) {}
+    , m_what("@" + rc::to_string(m_pos) + ": " + msg) {}
 
 std::string::size_type ParseException::position() const { return m_pos; }
 

--- a/src/detail/Results.cpp
+++ b/src/detail/Results.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "rapidcheck/Show.h"
+#include "rapidcheck/detail/Cpp11.h"
 
 namespace rc {
 namespace detail {
@@ -117,7 +118,7 @@ void printDistribution(const SuccessResult &result, std::ostream &os) {
 }
 
 void printResultMessage(const SuccessResult &result, std::ostream &os) {
-  os << "OK, passed " + std::to_string(result.numSuccess) + " tests";
+  os << "OK, passed " + rc::to_string(result.numSuccess) + " tests";
   if (!result.distribution.empty()) {
     os << std::endl;
     printDistribution(result, os);


### PR DESCRIPTION
When moving from BOOST_INCUDE_DIR into CMake's new dependency management, the dependency to Boost myst be explicitly declared