### PR TITLE
Add argument for "..." in variadic assert macros

### DIFF
--- a/include/rapidcheck/Assertions.h
+++ b/include/rapidcheck/Assertions.h
@@ -32,8 +32,7 @@
   RC_INTERNAL_CONDITIONAL_RESULT(Failure,                                      \
                                  expression,                                   \
                                  false,                                        \
-                                 "RC_ASSERT_"                                  \
-                                 "FALSE")
+                                 "RC_ASSERT_FALSE", )
 
 /// Fails the current test case unless the provided expression throws an
 /// exception of any type
@@ -81,7 +80,7 @@
 
 /// Succeed if the given condition is true.
 #define RC_SUCCEED_IF(expression)                                              \
-  RC_INTERNAL_CONDITIONAL_RESULT(Success, expression, false, "RC_SUCCEED_IF")
+  RC_INTERNAL_CONDITIONAL_RESULT(Success, expression, false, "RC_SUCCEED_IF", )
 
 /// Unconditionally succeed with the given message.
 #define RC_SUCCEED(...)                                                        \


### PR DESCRIPTION
As per GCC's error message: ISO C++11 requires at least one argument for
the "..." in a variadic macro. This can be noticed if compiling with
-pedantic, producing a warning. If -Werror is added, it becomes an
error. This PR adds a dummy last argument in all cases using the
RC_INTERNAL_CONDITIONAL_RESULT macro without one.

Tested on GCC 7.4.0 and Clang 6.0.0 .