### PR TITLE
Numeric: Fix Wimplicit-int-float-conversion with clang-10

### DIFF
--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -43,7 +43,7 @@ Shrinkable<T> real(const Random &random, int size) {
       std::min(size, kNominalSize) / static_cast<double>(kNominalSize);
   const double a = static_cast<double>(stream.nextWithSize<int64_t>(size));
   const double b =
-      (stream.next<uint64_t>() * scale) / std::numeric_limits<uint64_t>::max();
+      (stream.next<uint64_t>() * scale) / static_cast<double>(std::numeric_limits<uint64_t>::max());
   const T value = static_cast<T>(a + b);
   return shrinkable::shrinkRecur(value, &shrink::real<T>);
 }


### PR DESCRIPTION
Avoid warning by using explicit casting to double


`../include/rapidcheck/gen/Numeric.hpp:46:43: warning: implicit conversion from 'std::__1::numeric_limits<unsigned long long>::type' (aka 'unsigned long long') to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-int-float-conversion]`
```
      (stream.next<uint64_t>() * scale) / std::numeric_limits<uint64_t>::max();
                                        ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes #252 