### PR TITLE
SFINAE support for `Arbitrary` struct

### DIFF
--- a/include/rapidcheck/gen/Arbitrary.h
+++ b/include/rapidcheck/gen/Arbitrary.h
@@ -7,7 +7,7 @@ namespace rc {
 /// Specialize this template to provide default arbitrary generators for custom
 /// types. Specializations should have a static method `Gen<T> arbitrary()` that
 /// returns a suitable generator for generating arbitrary values of `T`.
-template <typename T>
+template <typename T, typename=void>
 struct Arbitrary;
 
 namespace gen {

--- a/include/rapidcheck/gen/Arbitrary.hpp
+++ b/include/rapidcheck/gen/Arbitrary.hpp
@@ -17,7 +17,7 @@ decltype(Arbitrary<T>::arbitrary()) arbitrary() {
 
 } // namespace gen
 
-template <typename T>
+template <typename T, typename>
 struct Arbitrary {
   static decltype(gen::detail::DefaultArbitrary<T>::arbitrary()) arbitrary() {
     return gen::detail::DefaultArbitrary<T>::arbitrary();


### PR DESCRIPTION
Added optional second type to `rc::Arbitrary` template to support single-type template specializations of `rc::Arbitrary` that use SFINAE patterns like `std::enable_if` to determine which one to choose.  It modifies the signature to be `template <typename T, typename=void> struct Arbitrary;`.

All existing `rapidcheck` unit tests passed with the change, which is 25 characters of total addition.  I don't see any explicit tests for `Arbitrary` anywhere so I wasn't sure if I should add anything to the tests.  I am assuming that it is implicitly tested quite well because it's fundamental to rapidcheck's data generation scheme, which is well tested.

For a little background and justification: I'm using rapidcheck in a project at $DAY_JOB to generate templated objects.  I want to optionally supply `rc::Arbitrary` generators for all classes that derive from those templated objects without requiring my users to write any code, unless you count including the `generators.h` header I will supply with the library.  The best way I could think of to do this is to have a template specialization that looks like this:

```c++
template <typename T>
struct Abitrary<T, typename std::enable_if<(std::is_base_of<MyBaseClass, T>::value)>::type> {
  static Gen<T> arbitrary() {
    ...
  }
}
```

The change in this PR allows for this, and for any other SFINAE patterns for filtering the template specialization of `Arbitrary` the compiler will select.