### PR TITLE
Inverted logic of rtti enablement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,8 @@ if(MINGW)
   target_compile_definitions(rapidcheck PRIVATE RC_SEED_SYSTEM_TIME)
 endif()
 
-if(RC_ENABLE_RTTI)
-  target_compile_definitions(rapidcheck PUBLIC RC_USE_RTTI)
+if(NOT RC_ENABLE_RTTI)
+  target_compile_definitions(rapidcheck PUBLIC RC_DONT_USE_RTTI)
 endif()
 
 add_subdirectory(ext)

--- a/include/rapidcheck/detail/Any.hpp
+++ b/include/rapidcheck/detail/Any.hpp
@@ -15,9 +15,9 @@ public:
   virtual void *get() = 0;
   virtual void showType(std::ostream &os) const = 0;
   virtual void showValue(std::ostream &os) const = 0;
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   virtual const std::type_info &typeInfo() const = 0;
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
   virtual ~IAnyImpl() = default;
 };
 
@@ -34,9 +34,9 @@ public:
 
   void showValue(std::ostream &os) const override { show(m_value, os); }
 
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   const std::type_info &typeInfo() const override { return typeid(T); }
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
 
 private:
   T m_value;
@@ -53,18 +53,18 @@ Any Any::of(T &&value) {
 template <typename T>
 const T &Any::get() const {
   assert(m_impl);
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   assert(m_impl->typeInfo() == typeid(T));
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
   return *static_cast<T *>(m_impl->get());
 }
 
 template <typename T>
 T &Any::get() {
   assert(m_impl);
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   assert(m_impl->typeInfo() == typeid(T));
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
   return *static_cast<T *>(m_impl->get());
 }
 

--- a/include/rapidcheck/detail/ShowType.hpp
+++ b/include/rapidcheck/detail/ShowType.hpp
@@ -44,11 +44,11 @@ struct ShowMultipleTypes<Type, Types...> {
 template <typename T>
 struct ShowType {
   static void showType(std::ostream &os) {
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
     os << detail::demangle(typeid(T).name());
 #else
     os << "[unknown type]";
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
   }
 };
 

--- a/include/rapidcheck/state/Command.hpp
+++ b/include/rapidcheck/state/Command.hpp
@@ -17,11 +17,11 @@ void Command<Model, Sut>::run(const Model &s0, Sut &sut) const {}
 
 template <typename Model, typename Sut>
 void Command<Model, Sut>::show(std::ostream &os) const {
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   os << ::rc::detail::demangle(typeid(*this).name());
 #else
   os << "[unknown command]";
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI
 }
 
 template <typename Model, typename Sut>

--- a/test/detail/ShowTypeTests.cpp
+++ b/test/detail/ShowTypeTests.cpp
@@ -8,7 +8,7 @@ using namespace rc;
 using namespace rc::test;
 using namespace rc::detail;
 
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
 TEST_CASE("typeToString") {
   SECTION("shows primitive types correctly") {
     REQUIRE(typeToString<void>() == "void");
@@ -167,4 +167,4 @@ TEST_CASE("typeToString") {
             "std::shared_ptr<const FFoo *>");
   }
 }
-#endif // RC_USE_RTTI
+#endif // RC_DONT_USE_RTTI

--- a/test/state/gen/ExecCommandsTests.cpp
+++ b/test/state/gen/ExecCommandsTests.cpp
@@ -50,7 +50,7 @@ struct GeneratesOnConstrution : public IntVecCmd {
 #endif // defined(__GNUC__) || defined(__clang__)
 
 TEST_CASE("state::gen::execOneOf") {
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   prop("returns one of the commands",
        [](const GenParams &params, const IntVec &s0) {
          const auto cmd =
@@ -98,7 +98,7 @@ TEST_CASE("state::gen::execOneOf") {
 #endif // defined(__GNUC__) || defined(__clang__)
 
 TEST_CASE("state::gen::execOneOfWithArgs") {
-#ifdef RC_USE_RTTI
+#ifndef RC_DONT_USE_RTTI
   prop("returns one of the commands",
        [](const GenParams &params, const IntVec &s0) {
          const auto cmd = state::gen::execOneOfWithArgs<A, B, C>()()(


### PR DESCRIPTION
Changed RC_USE_RTTI to RC_DONT_USE_RTTI and changed associated `#ifdef`s to `#ifndef`.

This PR is to solve #267 using suggested solution 1.  It's not backwards compatible, so I expect it will cause some breakage in some other projects if they are disabling RTTI in their environments.