### PR TITLE
Fix rc::compat::return_type definition warning

### DIFF
--- a/include/rapidcheck/Compat.hpp
+++ b/include/rapidcheck/Compat.hpp
@@ -5,7 +5,7 @@
 namespace rc {
 namespace compat {
 
-#if __cplusplus <= 201703L
+#if __cplusplus <= 201402L
 template <typename Fn, typename ...Args>
 using return_type = typename std::result_of<Fn(Args...)>;
 #else


### PR DESCRIPTION
Alias `rc::compat::return_type` to `std::result_of` for C++14 and earlier, instead of C++17 and earlier as it used to be.

The reason is that `std::result_of`, while still available in C++17, is deprecated and may result in warnings, for example warning STL4014 in Visual Studio 2017:

```
c:\project\thirdparty\rapidcheck\include\rapidcheck\compat.hpp(10): error C4996: 'std::result_of<_Callable(_Args...)>': warning STL4014: std::result_of and std::result_of_t are deprecated in C++17. They are superseded by std::invoke_result and std::invoke_result_t. You can define _SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning.
```