### PR TITLE
Remove implicit capture of this

### DIFF
--- a/include/rapidcheck/gen/Container.hpp
+++ b/include/rapidcheck/gen/Container.hpp
@@ -267,11 +267,11 @@ public:
     }
 
     return shrink::eachElement(shrinkables,
-                               [=](const Shrinkable<T> &s) {
+                               [this, keys](const Shrinkable<T> &s) {
                                  const auto valueKey = m_f(s.value());
                                  return seq::filter(
                                      s.shrinks(),
-                                     [=](const Shrinkable<T> &shrink) {
+                                     [this, keys, valueKey](const Shrinkable<T> &shrink) {
                                        const auto shrinkKey = m_f(shrink.value());
                                        return (!(valueKey < shrinkKey) &&
                                                !(shrinkKey < valueKey)) ||


### PR DESCRIPTION
GCC emits a deprecated warning when 'this' is implicitly captured by
value. Change the lambdas that were implicitly capturing to an explicit
capture.