### PR TITLE
boost_test: Add missing include for BOOST_CHECK, BOOST_FAIL

### DIFF
--- a/extras/boost_test/include/rapidcheck/boost_test.h
+++ b/extras/boost_test/include/rapidcheck/boost_test.h
@@ -4,6 +4,8 @@
 
 #include "rapidcheck/detail/ExecFixture.h"
 
+#include <boost/test/unit_test.hpp>
+
 namespace rc {
 namespace detail {
 


### PR DESCRIPTION
Without this, compilation fails if `rapidcheck/boost_test.h` is included before `boost/test/unit_test.h`.