### PR TITLE
boost: Update URL to download Boost

### DIFF
--- a/ext/get_boost.sh
+++ b/ext/get_boost.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-curl -s -L -o boost_1_68_0.tar.bz2 https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2
+curl -s -L -o boost_1_68_0.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.bz2
 tar xjfp boost_1_68_0.tar.bz2
 mv boost_1_68_0 boost
 rm boost_1_68_0.tar.bz2


### PR DESCRIPTION
The CI was failing in #275 because of a broken download link. This PR changes the URL to what is provided at https://www.boost.org/users/download/

The Boost version is not changed.