### PR TITLE
Remove the use of the deprecated `std::iterator`

### DIFF
--- a/include/rapidcheck/gen/detail/ShrinkValueIterator.hpp
+++ b/include/rapidcheck/gen/detail/ShrinkValueIterator.hpp
@@ -5,15 +5,15 @@ namespace gen {
 namespace detail {
 
 template <typename Iterator>
-class ShrinkValueIterator
-    : public std::iterator<
-          std::input_iterator_tag,
-          typename std::iterator_traits<Iterator>::value_type::ValueType,
-          std::ptrdiff_t,
-          typename std::iterator_traits<Iterator>::value_type::ValueType *,
-          typename std::iterator_traits<Iterator>::value_type::ValueType &&> {
+class ShrinkValueIterator {
 public:
   using T = typename std::iterator_traits<Iterator>::value_type::ValueType;
+
+  using iterator_category = std::input_iterator_tag;
+  using value_type = T;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T *;
+  using reference = T &&;
 
   ShrinkValueIterator(Iterator it)
       : m_it(it) {}

--- a/include/rapidcheck/seq/SeqIterator.h
+++ b/include/rapidcheck/seq/SeqIterator.h
@@ -5,8 +5,14 @@ namespace seq {
 
 /// STL iterator for `Seq`.
 template <typename T>
-class SeqIterator : public std::iterator<std::input_iterator_tag, T> {
+class SeqIterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = T;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T *;
+  using reference = T &;
+
   /// Creates a new past-the-end `SeqIterator`.
   SeqIterator() = default;
 


### PR DESCRIPTION
Using `std::iterator` as a base class has been deprecated since C++17, so this replaces it with the member types that it would define.

While I've done this change with C++17 in mind, this should be a fully-backwards compatible change with previous C++ standards.