### PR TITLE
Use `__cpp_lib_is_invocable` instead of `__cplusplus`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,11 +102,6 @@ if(MINGW)
   target_compile_definitions(rapidcheck PRIVATE RC_SEED_SYSTEM_TIME)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "^MSVC$")
-  # To reflect the language level (cf. https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160)
-  target_compile_options(rapidcheck PUBLIC /Zc:__cplusplus)
-endif ()
-
 if(NOT RC_ENABLE_RTTI)
   target_compile_definitions(rapidcheck PUBLIC RC_DONT_USE_RTTI)
 endif()

--- a/include/rapidcheck/Compat.hpp
+++ b/include/rapidcheck/Compat.hpp
@@ -5,12 +5,12 @@
 namespace rc {
 namespace compat {
 
-#if __cplusplus <= 201402L
-template <typename Fn, typename ...Args>
-using return_type = typename std::result_of<Fn(Args...)>;
-#else
+#if __cpp_lib_is_invocable >= 201703
 template <typename Fn, typename ...Args>
 using return_type = typename std::invoke_result<Fn,Args...>;
+#else
+template <typename Fn, typename ...Args>
+using return_type = typename std::result_of<Fn(Args...)>;
 #endif
 
 }


### PR DESCRIPTION
The fix for `std::result_of` being removed in C++20 checks `__cplusplus`, which isn't always set in MSVC, which also happens to be the compiler that removed `std::result_of`, so it adds `/Zc:__cplusplus` to the command line to fix this. This creates another problem however: When using the package in Clang, which doesn't support `/Zc:__cplusplus`, you get an error and it doesn't work. This is a problem for [vcpkg#22100](https://github.com/microsoft/vcpkg/pull/22100).

The solution is to use the feature test macro `__cpp_lib_is_invocable` instead, which tests exactly what we want to know.