### PR TITLE
Fix undefined behaviour in BitStream::nextWithSize

### DIFF
--- a/include/rapidcheck/detail/BitStream.h
+++ b/include/rapidcheck/detail/BitStream.h
@@ -18,6 +18,7 @@ public:
   T next();
 
   /// Returns the next random of the given type and number of bits.
+  /// nbits is capped at the number of bits in T
   template <typename T>
   T next(int nbits);
 

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -40,6 +40,7 @@ template <typename Source>
 template <typename T>
 T BitStream<Source>::next(int nbits, std::false_type) {
   using SourceType = decltype(m_source.next());
+  nbits = std::min(nbits, numBits<T>());
 
   if (nbits == 0) {
     return 0;


### PR DESCRIPTION
Fixes #289

Prior to this, calling `nextWithSize(kNominalSize + 1)` would result in a
call like `next<std::int64_t>(65)`. This lead to undefined behaviour in a
bit shift like `value |= (bits << 65)`. Calls such as this may happen
during testing as the size grows while trying to find problem cases.
