### PR TITLE
Very basic support for Catch2 v3

### DIFF
--- a/extras/catch/include/rapidcheck/catch.h
+++ b/extras/catch/include/rapidcheck/catch.h
@@ -3,7 +3,12 @@
 #include <sstream>
 
 #include <rapidcheck.h>
-#include <catch2/catch.hpp>
+
+// To support Catch2 v3 we check if the new header has already been included,
+// otherwise we include the old header.
+#ifndef CATCH_TEST_MACROS_HPP_INCLUDED
+  #include <catch2/catch.hpp>
+#endif
 
 namespace rc {
 

--- a/test/detail/BitStreamTests.cpp
+++ b/test/detail/BitStreamTests.cpp
@@ -51,7 +51,9 @@ TEST_CASE("BitStream") {
            const auto sizes = *bitSizes;
            int totalSize = 0;
            for (int size : sizes) {
-             totalSize += size;
+             // nbits is capped at 64 when reading a 64-bit integer,
+            //  so we have to cap it as well.
+             totalSize += std::min(size, 64);
              stream.next<uint64_t>(size);
            }
 


### PR DESCRIPTION
With the official release of [Catch2 v3.0.1](https://github.com/catchorg/Catch2/releases/tag/v3.0.1) the header structure of that library has changed, and this breaks compatibility with anyone including `<rapidcheck/catch.h>`, since it includes the old header.

The fix I've added is to not do anything if the user has already included the new `<catch2/catch_test_macros.hpp>` header. This should be compatible with any code that stays on v2.x versions of Catch2, and also compatible with anyone using the new major version of Catch2, with minor modifications, which they will have to make anyway when switching.

This does not touch any of RapidCheck's tests. The reason for this is Catch2 v3 is a C++14 library, and RapidCheck is currently a C++11 library.

Another change this pull request makes is fix a test failure introduced by #290. It fixed an instance of undefined behaviour in the library, but didn't update a test to reflect this change. This means CI should pass again (fingers crossed).
