### PR TITLE
Fix `rc::shrink::boolean` not compiling on msvc

### DIFF
--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -183,7 +183,7 @@ Seq<T> real(T value) {
   return seq::fromContainer(shrinks);
 }
 
-Seq<bool> boolean(bool value) { return value ? seq::just(false) : Seq<bool>(); }
+Seq<bool> boolean(bool value) { return value ? seq::just<bool>(false) : Seq<bool>(); }
 
 template <typename T>
 Seq<T> character(T value) {


### PR DESCRIPTION
MSVC complains with:
> shrink.hpp(182): error C2446: ':': no conversion from 'rc::Seq<bool>' to 'rc::Seq<int>'

This is remedied by being explicit with the template argument.

Fixes #298