### PR TITLE
Fix Issues raised by compiling with -Wsign-conversion

### DIFF
--- a/include/rapidcheck/Gen.h
+++ b/include/rapidcheck/Gen.h
@@ -13,7 +13,7 @@ class Random;
 /// This applies to, for example, generation of numbers but not to the
 /// generation of collection where there is an associated cost to generating
 /// large collections.
-constexpr size_t kNominalSize = 100;
+constexpr std::size_t kNominalSize = 100;
 
 /// This class is the type of RapidCheck generators. A generator is essentially
 /// a function which takes a `Random` and some generation parameters and returns
@@ -42,7 +42,7 @@ public:
   /// @param size    The generation size
   ///
   /// @return a random generated `Shrinkable`
-  Shrinkable<T> operator()(const Random &random, size_t size = kNominalSize) const
+  Shrinkable<T> operator()(const Random &random, std::size_t size = kNominalSize) const
       noexcept;
 
   /// The meaning of this operator depends on the context in which it is used

--- a/include/rapidcheck/Gen.h
+++ b/include/rapidcheck/Gen.h
@@ -13,7 +13,7 @@ class Random;
 /// This applies to, for example, generation of numbers but not to the
 /// generation of collection where there is an associated cost to generating
 /// large collections.
-constexpr int kNominalSize = 100;
+constexpr size_t kNominalSize = 100;
 
 /// This class is the type of RapidCheck generators. A generator is essentially
 /// a function which takes a `Random` and some generation parameters and returns
@@ -42,7 +42,7 @@ public:
   /// @param size    The generation size
   ///
   /// @return a random generated `Shrinkable`
-  Shrinkable<T> operator()(const Random &random, int size = kNominalSize) const
+  Shrinkable<T> operator()(const Random &random, size_t size = kNominalSize) const
       noexcept;
 
   /// The meaning of this operator depends on the context in which it is used

--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -21,7 +21,7 @@ Gen<Decay<typename rc::compat::return_type<Mapper,T>::type>> map(Gen<T> gen,
 template <typename T>
 class Gen<T>::IGenImpl {
 public:
-  virtual Shrinkable<T> generate(const Random &random, int size) const = 0;
+  virtual Shrinkable<T> generate(const Random &random, size_t size) const = 0;
   virtual void retain() = 0;
   virtual void release() = 0;
   virtual ~IGenImpl() = default;
@@ -36,7 +36,7 @@ public:
       : m_impl(std::forward<Args>(args)...)
       , m_count(1) {}
 
-  Shrinkable<T> generate(const Random &random, int size) const override {
+  Shrinkable<T> generate(const Random &random, size_t size) const override {
     return m_impl(random, size);
   }
 
@@ -64,7 +64,7 @@ std::string Gen<T>::name() const {
 }
 
 template <typename T>
-Shrinkable<T> Gen<T>::operator()(const Random &random, int size) const
+Shrinkable<T> Gen<T>::operator()(const Random &random, size_t size) const
     noexcept {
   try {
     return m_impl->generate(random, size);

--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -21,7 +21,7 @@ Gen<Decay<typename rc::compat::return_type<Mapper,T>::type>> map(Gen<T> gen,
 template <typename T>
 class Gen<T>::IGenImpl {
 public:
-  virtual Shrinkable<T> generate(const Random &random, size_t size) const = 0;
+  virtual Shrinkable<T> generate(const Random &random, std::size_t size) const = 0;
   virtual void retain() = 0;
   virtual void release() = 0;
   virtual ~IGenImpl() = default;
@@ -36,7 +36,7 @@ public:
       : m_impl(std::forward<Args>(args)...)
       , m_count(1) {}
 
-  Shrinkable<T> generate(const Random &random, size_t size) const override {
+  Shrinkable<T> generate(const Random &random, std::size_t size) const override {
     return m_impl(random, size);
   }
 
@@ -64,7 +64,7 @@ std::string Gen<T>::name() const {
 }
 
 template <typename T>
-Shrinkable<T> Gen<T>::operator()(const Random &random, size_t size) const
+Shrinkable<T> Gen<T>::operator()(const Random &random, std::size_t size) const
     noexcept {
   try {
     return m_impl->generate(random, size);

--- a/include/rapidcheck/detail/BitStream.h
+++ b/include/rapidcheck/detail/BitStream.h
@@ -25,7 +25,7 @@ public:
   /// Returns the next random of the given type and size. Size maxes out at
   /// `kNominalSize`.
   template <typename T>
-  T nextWithSize(int size);
+  T nextWithSize(size_t size);
 
 private:
   template <typename T>

--- a/include/rapidcheck/detail/BitStream.h
+++ b/include/rapidcheck/detail/BitStream.h
@@ -25,7 +25,7 @@ public:
   /// Returns the next random of the given type and size. Size maxes out at
   /// `kNominalSize`.
   template <typename T>
-  T nextWithSize(size_t size);
+  T nextWithSize(std::size_t size);
 
 private:
   template <typename T>

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -57,7 +57,7 @@ T BitStream<Source>::next(int nbits, std::false_type) {
 
     const auto n = std::min(m_numBits, wantBits);
     const auto bits = m_bits & bitMask<SourceType>(n);
-    value |= (bits << (nbits - wantBits));
+    value |= static_cast<T>(bits << (nbits - wantBits));
     // To avoid right-shifting data beyond the width of the given type (which is
     // undefined behavior, because of course it is) only perform this shift-
     // assignment if we have room.
@@ -84,7 +84,7 @@ T BitStream<Source>::next(int nbits, std::false_type) {
 
 template <typename Source>
 template <typename T>
-T BitStream<Source>::nextWithSize(int size) {
+T BitStream<Source>::nextWithSize(size_t size) {
   return next<T>((size * numBits<T>() + (kNominalSize / 2)) / kNominalSize);
 }
 

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -84,7 +84,7 @@ T BitStream<Source>::next(int nbits, std::false_type) {
 
 template <typename Source>
 template <typename T>
-T BitStream<Source>::nextWithSize(size_t size) {
+T BitStream<Source>::nextWithSize(std::size_t size) {
   return next<T>((size * numBits<T>() + (kNominalSize / 2)) / kNominalSize);
 }
 

--- a/include/rapidcheck/detail/Results.h
+++ b/include/rapidcheck/detail/Results.h
@@ -45,7 +45,7 @@ struct Reproduce {
   /// The Random to generate the shrinkable with.
   Random random;
   /// The size to generate the shrinkable with.
-  size_t size;
+  std::size_t size;
   /// The shrink path to follow.
   std::vector<std::size_t> shrinkPath;
 };

--- a/include/rapidcheck/detail/Results.h
+++ b/include/rapidcheck/detail/Results.h
@@ -45,7 +45,7 @@ struct Reproduce {
   /// The Random to generate the shrinkable with.
   Random random;
   /// The size to generate the shrinkable with.
-  int size;
+  size_t size;
   /// The shrink path to follow.
   std::vector<std::size_t> shrinkPath;
 };

--- a/include/rapidcheck/detail/Results.hpp
+++ b/include/rapidcheck/detail/Results.hpp
@@ -19,7 +19,7 @@ Iterator deserialize(Iterator begin, Iterator end, Reproduce &out) {
 
   std::uint32_t size;
   iit = deserialize(iit, end, size);
-  out.size = static_cast<int>(size);
+  out.size = size;
 
   out.shrinkPath.clear();
   const auto p = deserializeCompact<std::size_t>(

--- a/include/rapidcheck/detail/Serialization.hpp
+++ b/include/rapidcheck/detail/Serialization.hpp
@@ -2,6 +2,8 @@
 
 #include <limits>
 
+#include "rapidcheck/detail/Utility.h"
+
 namespace rc {
 namespace detail {
 
@@ -60,7 +62,7 @@ Iterator deserialize(Iterator begin, Iterator end, std::string &output) {
       throw SerializationException("Unexpected end of input");
     }
 
-    output.push_back(*iit);
+    output.push_back(makeSigned(*iit));
     iit++;
   }
 
@@ -203,7 +205,8 @@ Iterator deserializeCompact(Iterator begin, Iterator end, T &output) {
 template <typename InputIterator, typename OutputIterator>
 OutputIterator
 serializeCompact(InputIterator begin, InputIterator end, OutputIterator output) {
-  const std::uint64_t numElements = std::distance(begin, end);
+  auto dist = std::distance(begin, end);
+  const std::uint64_t numElements = makeUnsigned(dist);
   auto oit = serializeCompact(numElements, output);
   for (auto it = begin; it != end; it++) {
     oit = serializeCompact(*it, oit);

--- a/include/rapidcheck/detail/TestParams.h
+++ b/include/rapidcheck/detail/TestParams.h
@@ -11,11 +11,11 @@ struct TestParams {
   /// The seed to use.
   uint64_t seed = 0;
   /// The maximum number of successes before deciding a property passes.
-  int maxSuccess = 100;
+  std::size_t maxSuccess = 100;
   /// The maximum size to generate.
-  int maxSize = 100;
+  std::size_t maxSize = 100;
   /// The maximum allowed number of discarded tests per successful test.
-  int maxDiscardRatio = 10;
+  std::size_t maxDiscardRatio = 10;
   /// Whether shrinking should be disabled or not.
   bool disableShrinking = false;
 };

--- a/include/rapidcheck/gen/Container.hpp
+++ b/include/rapidcheck/gen/Container.hpp
@@ -28,7 +28,7 @@ Container toContainer(const Shrinkables<T> &shrinkables) {
 
 template <typename T, typename Predicate>
 Shrinkables<T> generateShrinkables(const Random &random,
-                                   int size,
+                                   size_t size,
                                    std::size_t count,
                                    const Gen<T> &gen,
                                    Predicate predicate) {
@@ -63,7 +63,7 @@ class CollectionStrategy {
 public:
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  int size,
+                                  size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     return generateShrinkables(random, size, count, gen, fn::constant(true));
@@ -86,7 +86,7 @@ class GenericContainerStrategy<Set, true, false> {
 public:
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  int size,
+                                  size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     Set set;
@@ -125,7 +125,7 @@ class GenericContainerStrategy<Map, true, true> {
 public:
   template <typename K, typename V>
   ShrinkablePairs<K, V> generateElements(const Random &random,
-                                         int size,
+                                         size_t size,
                                          std::size_t count,
                                          const Gen<K> &keyGen,
                                          const Gen<V> &valueGen) const {
@@ -190,7 +190,7 @@ class MultiMapStrategy : public CollectionStrategy<MultiMap> {
 public:
   template <typename K, typename V>
   ShrinkablePairs<K, V> generateElements(const Random &random,
-                                         int size,
+                                         size_t size,
                                          std::size_t count,
                                          const Gen<K> &keyGen,
                                          const Gen<V> &valueGen) const {
@@ -242,7 +242,7 @@ public:
 
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  int size,
+                                  size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     using Key = Decay<typename rc::compat::return_type<F,T>::type>;
@@ -292,7 +292,7 @@ public:
 
   template <typename... Ts>
   Shrinkable<Container>
-  generate(const Random &random, int size, const Gen<Ts> &... gens) const {
+  generate(const Random &random, size_t size, const Gen<Ts> &... gens) const {
     const auto strategy = m_strategy;
     auto r = random;
     std::size_t count = r.split().next() % (size + 1);
@@ -312,7 +312,7 @@ public:
   template <typename... Ts>
   Shrinkable<Container> generate(std::size_t count,
                                  const Random &random,
-                                 int size,
+                                 size_t size,
                                  const Gen<Ts> &... gens) const {
     const auto strategy = m_strategy;
     auto shrinkables = strategy.generateElements(random, size, count, gens...);
@@ -340,7 +340,7 @@ public:
 
   template <typename U>
   Shrinkable<Array>
-  generate(const Random &random, int size, const Gen<U> &gen) const {
+  generate(const Random &random, size_t size, const Gen<U> &gen) const {
     const auto strategy = m_strategy;
     auto shrinkables = strategy.generateElements(random, size, N, gen);
 
@@ -361,7 +361,7 @@ public:
   template <typename U>
   Shrinkable<Array> generate(std::size_t count,
                              const Random &random,
-                             int size,
+                             size_t size,
                              const Gen<U> &gen) const {
     if (count != N) {
       throw GenerationFailure(
@@ -488,7 +488,7 @@ Gen<Container> container(Gen<Ts>... gens) {
   using Strategy = detail::GenericContainerStrategy<Container>;
   detail::ContainerHelper<Container, Strategy> helper{Strategy()};
 
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return helper.generate(random, size, gens...);
   };
 }
@@ -498,7 +498,7 @@ Gen<Container> container(std::size_t count, Gen<Ts>... gens) {
   using Strategy = detail::GenericContainerStrategy<Container>;
   detail::ContainerHelper<Container, Strategy> helper{Strategy()};
 
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return helper.generate(count, random, size, gens...);
   };
 }
@@ -515,7 +515,7 @@ Gen<Container> uniqueBy(Gen<T> gen, F &&f) {
   detail::ContainerHelper<Container, Strategy> helper(
       Strategy(std::forward<F>(f)));
 
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return helper.generate(random, size, gen);
   };
 }
@@ -526,7 +526,7 @@ Gen<Container> uniqueBy(std::size_t count, Gen<T> gen, F &&f) {
   detail::ContainerHelper<Container, Strategy> helper(
       Strategy(std::forward<F>(f)));
 
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return helper.generate(count, random, size, gen);
   };
 }

--- a/include/rapidcheck/gen/Container.hpp
+++ b/include/rapidcheck/gen/Container.hpp
@@ -28,7 +28,7 @@ Container toContainer(const Shrinkables<T> &shrinkables) {
 
 template <typename T, typename Predicate>
 Shrinkables<T> generateShrinkables(const Random &random,
-                                   size_t size,
+                                   std::size_t size,
                                    std::size_t count,
                                    const Gen<T> &gen,
                                    Predicate predicate) {
@@ -63,7 +63,7 @@ class CollectionStrategy {
 public:
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  size_t size,
+                                  std::size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     return generateShrinkables(random, size, count, gen, fn::constant(true));
@@ -86,7 +86,7 @@ class GenericContainerStrategy<Set, true, false> {
 public:
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  size_t size,
+                                  std::size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     Set set;
@@ -125,7 +125,7 @@ class GenericContainerStrategy<Map, true, true> {
 public:
   template <typename K, typename V>
   ShrinkablePairs<K, V> generateElements(const Random &random,
-                                         size_t size,
+                                         std::size_t size,
                                          std::size_t count,
                                          const Gen<K> &keyGen,
                                          const Gen<V> &valueGen) const {
@@ -190,7 +190,7 @@ class MultiMapStrategy : public CollectionStrategy<MultiMap> {
 public:
   template <typename K, typename V>
   ShrinkablePairs<K, V> generateElements(const Random &random,
-                                         size_t size,
+                                         std::size_t size,
                                          std::size_t count,
                                          const Gen<K> &keyGen,
                                          const Gen<V> &valueGen) const {
@@ -242,7 +242,7 @@ public:
 
   template <typename T>
   Shrinkables<T> generateElements(const Random &random,
-                                  size_t size,
+                                  std::size_t size,
                                   std::size_t count,
                                   const Gen<T> &gen) const {
     using Key = Decay<typename rc::compat::return_type<F,T>::type>;
@@ -292,7 +292,7 @@ public:
 
   template <typename... Ts>
   Shrinkable<Container>
-  generate(const Random &random, size_t size, const Gen<Ts> &... gens) const {
+  generate(const Random &random, std::size_t size, const Gen<Ts> &... gens) const {
     const auto strategy = m_strategy;
     auto r = random;
     std::size_t count = r.split().next() % (size + 1);
@@ -312,7 +312,7 @@ public:
   template <typename... Ts>
   Shrinkable<Container> generate(std::size_t count,
                                  const Random &random,
-                                 size_t size,
+                                 std::size_t size,
                                  const Gen<Ts> &... gens) const {
     const auto strategy = m_strategy;
     auto shrinkables = strategy.generateElements(random, size, count, gens...);
@@ -340,7 +340,7 @@ public:
 
   template <typename U>
   Shrinkable<Array>
-  generate(const Random &random, size_t size, const Gen<U> &gen) const {
+  generate(const Random &random, std::size_t size, const Gen<U> &gen) const {
     const auto strategy = m_strategy;
     auto shrinkables = strategy.generateElements(random, size, N, gen);
 
@@ -361,7 +361,7 @@ public:
   template <typename U>
   Shrinkable<Array> generate(std::size_t count,
                              const Random &random,
-                             size_t size,
+                             std::size_t size,
                              const Gen<U> &gen) const {
     if (count != N) {
       throw GenerationFailure(
@@ -488,7 +488,7 @@ Gen<Container> container(Gen<Ts>... gens) {
   using Strategy = detail::GenericContainerStrategy<Container>;
   detail::ContainerHelper<Container, Strategy> helper{Strategy()};
 
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return helper.generate(random, size, gens...);
   };
 }
@@ -498,7 +498,7 @@ Gen<Container> container(std::size_t count, Gen<Ts>... gens) {
   using Strategy = detail::GenericContainerStrategy<Container>;
   detail::ContainerHelper<Container, Strategy> helper{Strategy()};
 
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return helper.generate(count, random, size, gens...);
   };
 }
@@ -515,7 +515,7 @@ Gen<Container> uniqueBy(Gen<T> gen, F &&f) {
   detail::ContainerHelper<Container, Strategy> helper(
       Strategy(std::forward<F>(f)));
 
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return helper.generate(random, size, gen);
   };
 }
@@ -526,7 +526,7 @@ Gen<Container> uniqueBy(std::size_t count, Gen<T> gen, F &&f) {
   detail::ContainerHelper<Container, Strategy> helper(
       Strategy(std::forward<F>(f)));
 
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return helper.generate(count, random, size, gen);
   };
 }

--- a/include/rapidcheck/gen/Create.hpp
+++ b/include/rapidcheck/gen/Create.hpp
@@ -16,7 +16,7 @@ template <typename Callable>
 Gen<typename rc::compat::return_type<Callable>::type::ValueType>
 lazy(Callable &&callable) {
   return
-      [=](const Random &random, size_t size) { return callable()(random, size); };
+      [=](const Random &random, std::size_t size) { return callable()(random, size); };
 }
 
 } // namespace gen

--- a/include/rapidcheck/gen/Create.hpp
+++ b/include/rapidcheck/gen/Create.hpp
@@ -16,7 +16,7 @@ template <typename Callable>
 Gen<typename rc::compat::return_type<Callable>::type::ValueType>
 lazy(Callable &&callable) {
   return
-      [=](const Random &random, int size) { return callable()(random, size); };
+      [=](const Random &random, size_t size) { return callable()(random, size); };
 }
 
 } // namespace gen

--- a/include/rapidcheck/gen/Maybe.hpp
+++ b/include/rapidcheck/gen/Maybe.hpp
@@ -10,7 +10,7 @@ public:
   MaybeGen(Gen<T> gen)
       : m_gen(std::move(gen)) {}
 
-  Shrinkable<Maybe<T>> operator()(const Random &random, size_t size) const {
+  Shrinkable<Maybe<T>> operator()(const Random &random, std::size_t size) const {
     auto r = random;
     const auto x = r.split().next() % (size + 1);
     if (x == 0) {

--- a/include/rapidcheck/gen/Maybe.hpp
+++ b/include/rapidcheck/gen/Maybe.hpp
@@ -10,7 +10,7 @@ public:
   MaybeGen(Gen<T> gen)
       : m_gen(std::move(gen)) {}
 
-  Shrinkable<Maybe<T>> operator()(const Random &random, int size) const {
+  Shrinkable<Maybe<T>> operator()(const Random &random, size_t size) const {
     auto r = random;
     const auto x = r.split().next() % (size + 1);
     if (x == 0) {

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -11,29 +11,29 @@ namespace gen {
 namespace detail {
 
 template <typename T>
-Shrinkable<T> integral(const Random &random, size_t size) {
+Shrinkable<T> integral(const Random &random, std::size_t size) {
   return shrinkable::shrinkRecur(
       rc::detail::bitStreamOf(random).nextWithSize<T>(size),
       &shrink::integral<T>);
 }
 
-extern template Shrinkable<char> integral<char>(const Random &random, size_t size);
+extern template Shrinkable<char> integral<char>(const Random &random, std::size_t size);
 extern template Shrinkable<unsigned char>
-integral<unsigned char>(const Random &random, size_t size);
+integral<unsigned char>(const Random &random, std::size_t size);
 extern template Shrinkable<short> integral<short>(const Random &random,
-                                                  size_t size);
+                                                  std::size_t size);
 extern template Shrinkable<unsigned short>
-integral<unsigned short>(const Random &random, size_t size);
-extern template Shrinkable<int> integral<int>(const Random &random, size_t size);
+integral<unsigned short>(const Random &random, std::size_t size);
+extern template Shrinkable<int> integral<int>(const Random &random, std::size_t size);
 extern template Shrinkable<unsigned int>
-integral<unsigned int>(const Random &random, size_t size);
-extern template Shrinkable<long> integral<long>(const Random &random, size_t size);
+integral<unsigned int>(const Random &random, std::size_t size);
+extern template Shrinkable<long> integral<long>(const Random &random, std::size_t size);
 extern template Shrinkable<unsigned long>
-integral<unsigned long>(const Random &random, size_t size);
+integral<unsigned long>(const Random &random, std::size_t size);
 extern template Shrinkable<long long> integral<long long>(const Random &random,
-                                                          size_t size);
+                                                          std::size_t size);
 extern template Shrinkable<unsigned long long>
-integral<unsigned long long>(const Random &random, size_t size);
+integral<unsigned long long>(const Random &random, std::size_t size);
 
 template <typename T>
 Shrinkable<T> real(const Random &random, std::size_t size) {
@@ -48,10 +48,10 @@ Shrinkable<T> real(const Random &random, std::size_t size) {
   return shrinkable::shrinkRecur(value, &shrink::real<T>);
 }
 
-extern template Shrinkable<float> real<float>(const Random &random, size_t size);
-extern template Shrinkable<double> real<double>(const Random &random, size_t size);
+extern template Shrinkable<float> real<float>(const Random &random, std::size_t size);
+extern template Shrinkable<double> real<double>(const Random &random, std::size_t size);
 
-Shrinkable<bool> boolean(const Random &random, size_t size);
+Shrinkable<bool> boolean(const Random &random, std::size_t size);
 
 template <typename T>
 struct DefaultArbitrary {
@@ -89,7 +89,7 @@ struct DefaultArbitrary<bool> {
 
 template <typename T>
 Gen<T> inRange(T min, T max) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     if (max <= min) {
       std::string msg;
       msg += "Invalid range [" + std::to_string(min);

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -11,32 +11,32 @@ namespace gen {
 namespace detail {
 
 template <typename T>
-Shrinkable<T> integral(const Random &random, int size) {
+Shrinkable<T> integral(const Random &random, size_t size) {
   return shrinkable::shrinkRecur(
       rc::detail::bitStreamOf(random).nextWithSize<T>(size),
       &shrink::integral<T>);
 }
 
-extern template Shrinkable<char> integral<char>(const Random &random, int size);
+extern template Shrinkable<char> integral<char>(const Random &random, size_t size);
 extern template Shrinkable<unsigned char>
-integral<unsigned char>(const Random &random, int size);
+integral<unsigned char>(const Random &random, size_t size);
 extern template Shrinkable<short> integral<short>(const Random &random,
-                                                  int size);
+                                                  size_t size);
 extern template Shrinkable<unsigned short>
-integral<unsigned short>(const Random &random, int size);
-extern template Shrinkable<int> integral<int>(const Random &random, int size);
+integral<unsigned short>(const Random &random, size_t size);
+extern template Shrinkable<int> integral<int>(const Random &random, size_t size);
 extern template Shrinkable<unsigned int>
-integral<unsigned int>(const Random &random, int size);
-extern template Shrinkable<long> integral<long>(const Random &random, int size);
+integral<unsigned int>(const Random &random, size_t size);
+extern template Shrinkable<long> integral<long>(const Random &random, size_t size);
 extern template Shrinkable<unsigned long>
-integral<unsigned long>(const Random &random, int size);
+integral<unsigned long>(const Random &random, size_t size);
 extern template Shrinkable<long long> integral<long long>(const Random &random,
-                                                          int size);
+                                                          size_t size);
 extern template Shrinkable<unsigned long long>
-integral<unsigned long long>(const Random &random, int size);
+integral<unsigned long long>(const Random &random, size_t size);
 
 template <typename T>
-Shrinkable<T> real(const Random &random, int size) {
+Shrinkable<T> real(const Random &random, std::size_t size) {
   // TODO this implementation sucks
   auto stream = rc::detail::bitStreamOf(random);
   const double scale =
@@ -48,10 +48,10 @@ Shrinkable<T> real(const Random &random, int size) {
   return shrinkable::shrinkRecur(value, &shrink::real<T>);
 }
 
-extern template Shrinkable<float> real<float>(const Random &random, int size);
-extern template Shrinkable<double> real<double>(const Random &random, int size);
+extern template Shrinkable<float> real<float>(const Random &random, size_t size);
+extern template Shrinkable<double> real<double>(const Random &random, size_t size);
 
-Shrinkable<bool> boolean(const Random &random, int size);
+Shrinkable<bool> boolean(const Random &random, size_t size);
 
 template <typename T>
 struct DefaultArbitrary {
@@ -89,7 +89,7 @@ struct DefaultArbitrary<bool> {
 
 template <typename T>
 Gen<T> inRange(T min, T max) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     if (max <= min) {
       std::string msg;
       msg += "Invalid range [" + std::to_string(min);

--- a/include/rapidcheck/gen/Predicate.hpp
+++ b/include/rapidcheck/gen/Predicate.hpp
@@ -12,7 +12,7 @@ public:
       : m_predicate(std::forward<PredicateArg>(predicate))
       , m_gen(std::move(gen)) {}
 
-  Shrinkable<T> operator()(const Random &random, int size) const {
+  Shrinkable<T> operator()(const Random &random, size_t size) const {
     Random r(random);
     int currentSize = size;
     for (int tries = 0; tries < 100; tries++) {

--- a/include/rapidcheck/gen/Predicate.hpp
+++ b/include/rapidcheck/gen/Predicate.hpp
@@ -12,7 +12,7 @@ public:
       : m_predicate(std::forward<PredicateArg>(predicate))
       , m_gen(std::move(gen)) {}
 
-  Shrinkable<T> operator()(const Random &random, size_t size) const {
+  Shrinkable<T> operator()(const Random &random, std::size_t size) const {
     Random r(random);
     int currentSize = size;
     for (int tries = 0; tries < 100; tries++) {

--- a/include/rapidcheck/gen/Select.hpp
+++ b/include/rapidcheck/gen/Select.hpp
@@ -92,7 +92,7 @@ public:
   explicit SizedElementOfGen(Arg &&arg)
       : m_container(std::forward<Arg>(arg)) {}
 
-  Shrinkable<T> operator()(const Random &random, int size) const {
+  Shrinkable<T> operator()(const Random &random, size_t size) const {
     if (m_container.size() == 0) {
       throw GenerationFailure("Cannot pick element from empty container.");
     }
@@ -117,7 +117,7 @@ public:
   OneOfGen(Gen<Ts>... gens)
       : m_gens{std::move(gens)...} {}
 
-  Shrinkable<T> operator()(const Random &random, int size) const {
+  Shrinkable<T> operator()(const Random &random, size_t size) const {
     Random r(random);
     const auto i = static_cast<std::size_t>(r.split().next() % m_gens.size());
     return m_gens[i](r, size);

--- a/include/rapidcheck/gen/Select.hpp
+++ b/include/rapidcheck/gen/Select.hpp
@@ -92,7 +92,7 @@ public:
   explicit SizedElementOfGen(Arg &&arg)
       : m_container(std::forward<Arg>(arg)) {}
 
-  Shrinkable<T> operator()(const Random &random, size_t size) const {
+  Shrinkable<T> operator()(const Random &random, std::size_t size) const {
     if (m_container.size() == 0) {
       throw GenerationFailure("Cannot pick element from empty container.");
     }
@@ -117,7 +117,7 @@ public:
   OneOfGen(Gen<Ts>... gens)
       : m_gens{std::move(gens)...} {}
 
-  Shrinkable<T> operator()(const Random &random, size_t size) const {
+  Shrinkable<T> operator()(const Random &random, std::size_t size) const {
     Random r(random);
     const auto i = static_cast<std::size_t>(r.split().next() % m_gens.size());
     return m_gens[i](r, size);

--- a/include/rapidcheck/gen/Text.hpp
+++ b/include/rapidcheck/gen/Text.hpp
@@ -17,7 +17,7 @@ class StringGen<std::basic_string<T, Args...>> {
 public:
   using String = std::basic_string<T, Args...>;
 
-  Shrinkable<String> operator()(const Random &random, int size) const {
+  Shrinkable<String> operator()(const Random &random, size_t size) const {
     auto stream = rc::detail::bitStreamOf(random);
     String str;
     auto length = stream.next<std::size_t>() % (size + 1);

--- a/include/rapidcheck/gen/Text.hpp
+++ b/include/rapidcheck/gen/Text.hpp
@@ -17,7 +17,7 @@ class StringGen<std::basic_string<T, Args...>> {
 public:
   using String = std::basic_string<T, Args...>;
 
-  Shrinkable<String> operator()(const Random &random, size_t size) const {
+  Shrinkable<String> operator()(const Random &random, std::size_t size) const {
     auto stream = rc::detail::bitStreamOf(random);
     String str;
     auto length = stream.next<std::size_t>() % (size + 1);

--- a/include/rapidcheck/gen/Transform.h
+++ b/include/rapidcheck/gen/Transform.h
@@ -43,7 +43,7 @@ Gen<T> cast(Gen<U> gen);
 /// Returns a version of the given generator that always uses the specified
 /// size.
 template <typename T>
-Gen<T> resize(size_t size, Gen<T> gen);
+Gen<T> resize(std::size_t size, Gen<T> gen);
 
 /// Returns a version of the given generator that scales the size by the given
 /// factor before passing it to the underlying generator.

--- a/include/rapidcheck/gen/Transform.h
+++ b/include/rapidcheck/gen/Transform.h
@@ -43,7 +43,7 @@ Gen<T> cast(Gen<U> gen);
 /// Returns a version of the given generator that always uses the specified
 /// size.
 template <typename T>
-Gen<T> resize(int size, Gen<T> gen);
+Gen<T> resize(size_t size, Gen<T> gen);
 
 /// Returns a version of the given generator that scales the size by the given
 /// factor before passing it to the underlying generator.

--- a/include/rapidcheck/gen/Transform.hpp
+++ b/include/rapidcheck/gen/Transform.hpp
@@ -21,7 +21,7 @@ public:
       : m_mapper(std::forward<MapperArg>(mapper))
       , m_gen(std::move(gen)) {}
 
-  Shrinkable<U> operator()(const Random &random, size_t size) const {
+  Shrinkable<U> operator()(const Random &random, std::size_t size) const {
     return shrinkable::map(m_gen(random, size), m_mapper);
   }
 
@@ -40,7 +40,7 @@ public:
       : m_gen(std::move(gen))
       , m_mapper(std::forward<MapperArg>(mapper)) {}
 
-  Shrinkable<U> operator()(const Random &random, size_t size) const {
+  Shrinkable<U> operator()(const Random &random, std::size_t size) const {
     auto r1 = random;
     auto r2 = r1.split();
     const auto mapper = m_mapper;
@@ -59,7 +59,7 @@ public:
   explicit JoinGen(Gen<Gen<T>> gen)
       : m_gen(std::move(gen)) {}
 
-  Shrinkable<T> operator()(const Random &random, size_t size) const {
+  Shrinkable<T> operator()(const Random &random, std::size_t size) const {
     auto r1 = random;
     auto r2 = r1.split();
     return shrinkable::mapcat(
@@ -113,13 +113,13 @@ Gen<T> cast(Gen<U> gen) {
 }
 
 template <typename T>
-Gen<T> resize(size_t size, Gen<T> gen) {
+Gen<T> resize(std::size_t size, Gen<T> gen) {
   return [=](const Random &random, int) { return gen(random, size); };
 }
 
 template <typename T>
 Gen<T> scale(double scale, Gen<T> gen) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return gen(random, static_cast<int>(size * scale));
   };
 }
@@ -127,14 +127,14 @@ Gen<T> scale(double scale, Gen<T> gen) {
 template <typename Callable>
 Gen<typename rc::compat::return_type<Callable,int>::type::ValueType>
 withSize(Callable &&callable) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return callable(size)(random, size);
   };
 }
 
 template <typename T>
 Gen<T> noShrink(Gen<T> gen) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return shrinkable::mapShrinks(gen(random, size),
                                   fn::constant(Seq<Shrinkable<T>>()));
   };
@@ -142,7 +142,7 @@ Gen<T> noShrink(Gen<T> gen) {
 
 template <typename T, typename Shrink>
 Gen<T> shrink(Gen<T> gen, Shrink &&shrink) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     return shrinkable::postShrink(gen(random, size), shrink);
   };
 }

--- a/include/rapidcheck/gen/Transform.hpp
+++ b/include/rapidcheck/gen/Transform.hpp
@@ -21,7 +21,7 @@ public:
       : m_mapper(std::forward<MapperArg>(mapper))
       , m_gen(std::move(gen)) {}
 
-  Shrinkable<U> operator()(const Random &random, int size) const {
+  Shrinkable<U> operator()(const Random &random, size_t size) const {
     return shrinkable::map(m_gen(random, size), m_mapper);
   }
 
@@ -40,7 +40,7 @@ public:
       : m_gen(std::move(gen))
       , m_mapper(std::forward<MapperArg>(mapper)) {}
 
-  Shrinkable<U> operator()(const Random &random, int size) const {
+  Shrinkable<U> operator()(const Random &random, size_t size) const {
     auto r1 = random;
     auto r2 = r1.split();
     const auto mapper = m_mapper;
@@ -59,7 +59,7 @@ public:
   explicit JoinGen(Gen<Gen<T>> gen)
       : m_gen(std::move(gen)) {}
 
-  Shrinkable<T> operator()(const Random &random, int size) const {
+  Shrinkable<T> operator()(const Random &random, size_t size) const {
     auto r1 = random;
     auto r2 = r1.split();
     return shrinkable::mapcat(
@@ -113,13 +113,13 @@ Gen<T> cast(Gen<U> gen) {
 }
 
 template <typename T>
-Gen<T> resize(int size, Gen<T> gen) {
+Gen<T> resize(size_t size, Gen<T> gen) {
   return [=](const Random &random, int) { return gen(random, size); };
 }
 
 template <typename T>
 Gen<T> scale(double scale, Gen<T> gen) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return gen(random, static_cast<int>(size * scale));
   };
 }
@@ -127,14 +127,14 @@ Gen<T> scale(double scale, Gen<T> gen) {
 template <typename Callable>
 Gen<typename rc::compat::return_type<Callable,int>::type::ValueType>
 withSize(Callable &&callable) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return callable(size)(random, size);
   };
 }
 
 template <typename T>
 Gen<T> noShrink(Gen<T> gen) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return shrinkable::mapShrinks(gen(random, size),
                                   fn::constant(Seq<Shrinkable<T>>()));
   };
@@ -142,7 +142,7 @@ Gen<T> noShrink(Gen<T> gen) {
 
 template <typename T, typename Shrink>
 Gen<T> shrink(Gen<T> gen, Shrink &&shrink) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     return shrinkable::postShrink(gen(random, size), shrink);
   };
 }

--- a/include/rapidcheck/gen/Tuple.hpp
+++ b/include/rapidcheck/gen/Tuple.hpp
@@ -91,7 +91,7 @@ public:
       : m_gens(std::forward<Args>(args)...) {}
 
   Shrinkable<std::tuple<Ts...>> operator()(const Random &random,
-                                           size_t size) const {
+                                           std::size_t size) const {
     auto r = random;
     Random randoms[sizeof...(Ts)];
     for (std::size_t i = 0; i < sizeof...(Ts); i++) {

--- a/include/rapidcheck/gen/Tuple.hpp
+++ b/include/rapidcheck/gen/Tuple.hpp
@@ -91,7 +91,7 @@ public:
       : m_gens(std::forward<Args>(args)...) {}
 
   Shrinkable<std::tuple<Ts...>> operator()(const Random &random,
-                                           int size) const {
+                                           size_t size) const {
     auto r = random;
     Random randoms[sizeof...(Ts)];
     for (std::size_t i = 0; i < sizeof...(Ts); i++) {

--- a/include/rapidcheck/gen/detail/ExecRaw.hpp
+++ b/include/rapidcheck/gen/detail/ExecRaw.hpp
@@ -56,7 +56,7 @@ shrinkableWithRecipe(Callable callable, Recipe recipe) {
 template <typename Callable>
 Gen<std::pair<rc::detail::ReturnType<Callable>, Recipe>>
 execRaw(Callable callable) {
-  return [=](const Random &random, int size) {
+  return [=](const Random &random, size_t size) {
     Recipe recipe;
     recipe.random = random;
     recipe.size = size;

--- a/include/rapidcheck/gen/detail/ExecRaw.hpp
+++ b/include/rapidcheck/gen/detail/ExecRaw.hpp
@@ -56,7 +56,7 @@ shrinkableWithRecipe(Callable callable, Recipe recipe) {
 template <typename Callable>
 Gen<std::pair<rc::detail::ReturnType<Callable>, Recipe>>
 execRaw(Callable callable) {
-  return [=](const Random &random, size_t size) {
+  return [=](const Random &random, std::size_t size) {
     Recipe recipe;
     recipe.random = random;
     recipe.size = size;

--- a/include/rapidcheck/gen/detail/Recipe.h
+++ b/include/rapidcheck/gen/detail/Recipe.h
@@ -36,7 +36,7 @@ struct Recipe {
   using Ingredients = std::vector<Ingredient>;
 
   Random random;
-  int size = 0;
+  size_t size = 0;
   Ingredients ingredients;
   std::size_t numFixed = 0;
 };

--- a/include/rapidcheck/gen/detail/Recipe.h
+++ b/include/rapidcheck/gen/detail/Recipe.h
@@ -36,7 +36,7 @@ struct Recipe {
   using Ingredients = std::vector<Ingredient>;
 
   Random random;
-  size_t size = 0;
+  std::size_t size = 0;
   Ingredients ingredients;
   std::size_t numFixed = 0;
 };

--- a/include/rapidcheck/gen/detail/ScaleInteger.h
+++ b/include/rapidcheck/gen/detail/ScaleInteger.h
@@ -8,7 +8,7 @@ namespace detail {
 
 /// Scales a 64-bit integer according to `size` without overflows. `size` maxes
 /// out at `100`.
-uint64_t scaleInteger(uint64_t rangeSize, int size);
+uint64_t scaleInteger(uint64_t rangeSize, std::size_t size);
 
 } // namespace detail
 } // namespace gen

--- a/include/rapidcheck/seq/Create.hpp
+++ b/include/rapidcheck/seq/Create.hpp
@@ -19,7 +19,7 @@ private:
   T m_value;
 };
 
-template <typename T, size_t N>
+template <typename T, std::size_t N>
 class JustSeq {
 public:
   template <typename... Args>

--- a/include/rapidcheck/seq/Create.hpp
+++ b/include/rapidcheck/seq/Create.hpp
@@ -19,7 +19,7 @@ private:
   T m_value;
 };
 
-template <typename T, int N>
+template <typename T, size_t N>
 class JustSeq {
 public:
   template <typename... Args>

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -6,6 +6,7 @@
 #include "rapidcheck/seq/Transform.h"
 #include "rapidcheck/seq/Create.h"
 #include "rapidcheck/Compat.h"
+#include "rapidcheck/detail/Utility.h"
 
 namespace rc {
 namespace shrink {
@@ -14,27 +15,23 @@ namespace detail {
 template <typename T>
 class TowardsSeq {
 public:
-  using UInt = typename std::make_unsigned<T>::type;
-
   TowardsSeq(T value, T target)
       : m_value(value)
-      , m_diff((target < value) ? (value - target) : (target - value))
-      , m_down(target < value) {}
+      , m_diff(target - value) {}
 
   Maybe<T> operator()() {
     if (m_diff == 0) {
       return Nothing;
     }
 
-    T ret = m_down ? (m_value - m_diff) : (m_value + m_diff);
+    T ret = m_value + m_diff;
     m_diff /= 2;
     return ret;
   }
 
 private:
   T m_value;
-  UInt m_diff;
-  bool m_down;
+  T m_diff;
 };
 
 template <typename Container>
@@ -55,8 +52,8 @@ public:
     elements.reserve(m_elements.size() - m_size);
     const auto start = begin(m_elements);
     const auto fin = end(m_elements);
-    elements.insert(end(elements), start, start + m_start);
-    elements.insert(end(elements), start + m_start + m_size, fin);
+    elements.insert(end(elements), start, start + rc::detail::makeSigned(m_start));
+    elements.insert(end(elements), start + rc::detail::makeSigned(m_start) + rc::detail::makeSigned(m_size), fin);
 
     if ((m_size + m_start) >= m_elements.size()) {
       m_size--;

--- a/include/rapidcheck/state/gen/Commands.hpp
+++ b/include/rapidcheck/state/gen/Commands.hpp
@@ -26,7 +26,7 @@ public:
       : m_initialState(std::forward<InitialStateArg>(initialState))
       , m_genFunc(std::forward<GenFuncArg>(genFunc)) {}
 
-  Shrinkable<Commands<Cmd>> operator()(const Random &random, size_t size) const {
+  Shrinkable<Commands<Cmd>> operator()(const Random &random, std::size_t size) const {
     auto sequenceShrinkable = shrinkable::shrinkRecur(
         CommandSequence(m_initialState, random, m_genFunc, size),
         [](const CommandSequence &commandSequence) {
@@ -81,7 +81,7 @@ private:
     CommandSequence(const MakeInitialState &initState,
                     const Random &random,
                     const GenFunc &func,
-                    size_t sz)
+                    std::size_t sz)
         : m_initialState(initState)
         , m_genFunc(func)
         , m_size(sz) {
@@ -240,7 +240,7 @@ private:
 
     MakeInitialState m_initialState;
     GenFunc m_genFunc;
-    size_t m_size;
+    std::size_t m_size;
     std::vector<CommandEntry> m_entries;
   };
 

--- a/include/rapidcheck/state/gen/Commands.hpp
+++ b/include/rapidcheck/state/gen/Commands.hpp
@@ -26,7 +26,7 @@ public:
       : m_initialState(std::forward<InitialStateArg>(initialState))
       , m_genFunc(std::forward<GenFuncArg>(genFunc)) {}
 
-  Shrinkable<Commands<Cmd>> operator()(const Random &random, int size) const {
+  Shrinkable<Commands<Cmd>> operator()(const Random &random, size_t size) const {
     auto sequenceShrinkable = shrinkable::shrinkRecur(
         CommandSequence(m_initialState, random, m_genFunc, size),
         [](const CommandSequence &commandSequence) {
@@ -81,7 +81,7 @@ private:
     CommandSequence(const MakeInitialState &initState,
                     const Random &random,
                     const GenFunc &func,
-                    int sz)
+                    size_t sz)
         : m_initialState(initState)
         , m_genFunc(func)
         , m_size(sz) {
@@ -240,7 +240,7 @@ private:
 
     MakeInitialState m_initialState;
     GenFunc m_genFunc;
-    int m_size;
+    size_t m_size;
     std::vector<CommandEntry> m_entries;
   };
 

--- a/include/rapidcheck/state/gen/ExecCommands.hpp
+++ b/include/rapidcheck/state/gen/ExecCommands.hpp
@@ -46,7 +46,7 @@ public:
   OneOfCmdGen(Ts &&... args)
       : m_args(std::forward<Ts>(args)...) {}
 
-  Shrinkable<CmdSP> operator()(const Random &random, int size) const {
+  Shrinkable<CmdSP> operator()(const Random &random, size_t size) const {
     using MakeFunc = CmdSP (*)(const Args &...);
     using ArgsList = TypeList<Args...>;
     static const MakeFunc makeFuncs[] = {&MakeCommand<Cmd, ArgsList>::make,

--- a/include/rapidcheck/state/gen/ExecCommands.hpp
+++ b/include/rapidcheck/state/gen/ExecCommands.hpp
@@ -46,7 +46,7 @@ public:
   OneOfCmdGen(Ts &&... args)
       : m_args(std::forward<Ts>(args)...) {}
 
-  Shrinkable<CmdSP> operator()(const Random &random, size_t size) const {
+  Shrinkable<CmdSP> operator()(const Random &random, std::size_t size) const {
     using MakeFunc = CmdSP (*)(const Args &...);
     using ArgsList = TypeList<Args...>;
     static const MakeFunc makeFuncs[] = {&MakeCommand<Cmd, ArgsList>::make,

--- a/src/detail/Base64.cpp
+++ b/src/detail/Base64.cpp
@@ -36,16 +36,21 @@ std::string base64Encode(const std::vector<std::uint8_t> &data) {
   output.reserve(outputSize);
 
   for (std::size_t i = 0; i < size; i += 3) {
-    int nbits = 0;
+    size_t nbits = 0;
     std::uint32_t bits = 0;
     for (std::size_t j = i; j < std::min<std::size_t>(size, i + 3); j++) {
-      bits |= data[j] << nbits;
+      bits |= static_cast<std::uint32_t>(data[j] << nbits);
       nbits += 8;
     }
 
     while (nbits > 0) {
       output.append(1, kBase64Alphabet[bits & 0x3F]);
-      nbits -= 6;
+      if (nbits >= 6) {
+        // Prevent underflow of size_t
+        nbits -= 6;
+      } else {
+        nbits = 0;
+      }
       bits = bits >> 6;
     }
   }
@@ -72,7 +77,7 @@ std::vector<std::uint8_t> base64Decode(const std::string &data) {
       if (x == -1) {
         throw ParseException(j, "Invalid Base64 character");
       }
-      bits |= x << nbits;
+      bits |= static_cast<std::uint32_t>(x << nbits);
       nbits += 6;
     }
 

--- a/src/detail/Base64.cpp
+++ b/src/detail/Base64.cpp
@@ -36,7 +36,7 @@ std::string base64Encode(const std::vector<std::uint8_t> &data) {
   output.reserve(outputSize);
 
   for (std::size_t i = 0; i < size; i += 3) {
-    size_t nbits = 0;
+    std::size_t nbits = 0;
     std::uint32_t bits = 0;
     for (std::size_t j = i; j < std::min<std::size_t>(size, i + 3); j++) {
       bits |= static_cast<std::uint32_t>(data[j] << nbits);
@@ -46,7 +46,7 @@ std::string base64Encode(const std::vector<std::uint8_t> &data) {
     while (nbits > 0) {
       output.append(1, kBase64Alphabet[bits & 0x3F]);
       if (nbits >= 6) {
-        // Prevent underflow of size_t
+        // Prevent underflow of std::size_t
         nbits -= 6;
       } else {
         nbits = 0;

--- a/src/detail/FrequencyMap.cpp
+++ b/src/detail/FrequencyMap.cpp
@@ -15,7 +15,10 @@ FrequencyMap::FrequencyMap(const std::vector<std::size_t> &frequencies)
 }
 
 std::size_t FrequencyMap::lookup(std::size_t x) const {
-  return std::upper_bound(begin(m_table), end(m_table), x) - begin(m_table);
+  // upper_bound(first, last, x) will always return in the range [first, last]
+  // Therefore upper_bound(begin(m_table), ...) - begin(m_table) will be >= 0
+  return static_cast<std::size_t>(
+    std::upper_bound(begin(m_table), end(m_table), x) - begin(m_table));
 }
 
 std::size_t FrequencyMap::sum() const { return m_sum; }

--- a/src/detail/Testing.cpp
+++ b/src/detail/Testing.cpp
@@ -39,7 +39,7 @@ SearchResult searchProperty(const Property &property,
 
   const auto maxDiscard = params.maxDiscardRatio * params.maxSuccess;
 
-  size_t recentDiscards = 0;
+  std::size_t recentDiscards = 0;
   auto r = Random(params.seed);
   while (searchResult.numSuccess < params.maxSuccess) {
     const auto size =

--- a/src/detail/Testing.cpp
+++ b/src/detail/Testing.cpp
@@ -7,7 +7,7 @@ namespace rc {
 namespace detail {
 namespace {
 
-int sizeFor(const TestParams &params, int i) {
+size_t sizeFor(const TestParams &params, std::size_t i) {
   // We want sizes to be evenly spread, even when maxSuccess is not an even
   // multiple of the number of sizes (i.e. maxSize + 1). Another thing is that
   // we always want to ensure that the maximum size is actually used.
@@ -39,7 +39,7 @@ SearchResult searchProperty(const Property &property,
 
   const auto maxDiscard = params.maxDiscardRatio * params.maxSuccess;
 
-  auto recentDiscards = 0;
+  size_t recentDiscards = 0;
   auto r = Random(params.seed);
   while (searchResult.numSuccess < params.maxSuccess) {
     const auto size =

--- a/src/detail/Testing.h
+++ b/src/detail/Testing.h
@@ -17,7 +17,7 @@ struct SearchResult {
 
   /// Represents information about a failure.
   struct Failure {
-    Failure(Shrinkable<CaseDescription> shr, size_t sz, const Random &rnd)
+    Failure(Shrinkable<CaseDescription> shr, std::size_t sz, const Random &rnd)
         : shrinkable(shr)
         , size(sz)
         , random(rnd) {}
@@ -26,7 +26,7 @@ struct SearchResult {
     Shrinkable<CaseDescription> shrinkable;
 
     /// The size at which the property failed.
-    size_t size;
+    std::size_t size;
 
     /// The Random state which produced the failure.
     Random random;

--- a/src/detail/Testing.h
+++ b/src/detail/Testing.h
@@ -17,7 +17,7 @@ struct SearchResult {
 
   /// Represents information about a failure.
   struct Failure {
-    Failure(Shrinkable<CaseDescription> shr, int sz, const Random &rnd)
+    Failure(Shrinkable<CaseDescription> shr, size_t sz, const Random &rnd)
         : shrinkable(shr)
         , size(sz)
         , random(rnd) {}
@@ -26,7 +26,7 @@ struct SearchResult {
     Shrinkable<CaseDescription> shrinkable;
 
     /// The size at which the property failed.
-    int size;
+    size_t size;
 
     /// The Random state which produced the failure.
     Random random;
@@ -36,10 +36,10 @@ struct SearchResult {
   Type type;
 
   /// The number of successful test cases.
-  int numSuccess;
+  std::size_t numSuccess;
 
   /// The number of discarded test cases.
-  int numDiscarded;
+  std::size_t numDiscarded;
 
   /// The tags of successful test cases.
   std::vector<Tags> tags;

--- a/src/gen/Numeric.cpp
+++ b/src/gen/Numeric.cpp
@@ -4,27 +4,27 @@ namespace rc {
 namespace gen {
 namespace detail {
 
-template Shrinkable<char> integral<char>(const Random &random, size_t size);
+template Shrinkable<char> integral<char>(const Random &random, std::size_t size);
 template Shrinkable<unsigned char> integral<unsigned char>(const Random &random,
-                                                           size_t size);
-template Shrinkable<short> integral<short>(const Random &random, size_t size);
+                                                           std::size_t size);
+template Shrinkable<short> integral<short>(const Random &random, std::size_t size);
 template Shrinkable<unsigned short>
-integral<unsigned short>(const Random &random, size_t size);
-template Shrinkable<int> integral<int>(const Random &random, size_t size);
+integral<unsigned short>(const Random &random, std::size_t size);
+template Shrinkable<int> integral<int>(const Random &random, std::size_t size);
 template Shrinkable<unsigned int> integral<unsigned int>(const Random &random,
-                                                         size_t size);
-template Shrinkable<long> integral<long>(const Random &random, size_t size);
+                                                         std::size_t size);
+template Shrinkable<long> integral<long>(const Random &random, std::size_t size);
 template Shrinkable<unsigned long> integral<unsigned long>(const Random &random,
-                                                           size_t size);
+                                                           std::size_t size);
 template Shrinkable<long long> integral<long long>(const Random &random,
-                                                   size_t size);
+                                                   std::size_t size);
 template Shrinkable<unsigned long long>
-integral<unsigned long long>(const Random &random, size_t size);
+integral<unsigned long long>(const Random &random, std::size_t size);
 
-template Shrinkable<float> real<float>(const Random &random, size_t size);
-template Shrinkable<double> real<double>(const Random &random, size_t size);
+template Shrinkable<float> real<float>(const Random &random, std::size_t size);
+template Shrinkable<double> real<double>(const Random &random, std::size_t size);
 
-Shrinkable<bool> boolean(const Random &random, size_t /*size*/) {
+Shrinkable<bool> boolean(const Random &random, std::size_t /*size*/) {
   return shrinkable::shrinkRecur(rc::detail::bitStreamOf(random).next<bool>(),
                                  &shrink::boolean);
 }

--- a/src/gen/Numeric.cpp
+++ b/src/gen/Numeric.cpp
@@ -4,27 +4,27 @@ namespace rc {
 namespace gen {
 namespace detail {
 
-template Shrinkable<char> integral<char>(const Random &random, int size);
+template Shrinkable<char> integral<char>(const Random &random, size_t size);
 template Shrinkable<unsigned char> integral<unsigned char>(const Random &random,
-                                                           int size);
-template Shrinkable<short> integral<short>(const Random &random, int size);
+                                                           size_t size);
+template Shrinkable<short> integral<short>(const Random &random, size_t size);
 template Shrinkable<unsigned short>
-integral<unsigned short>(const Random &random, int size);
-template Shrinkable<int> integral<int>(const Random &random, int size);
+integral<unsigned short>(const Random &random, size_t size);
+template Shrinkable<int> integral<int>(const Random &random, size_t size);
 template Shrinkable<unsigned int> integral<unsigned int>(const Random &random,
-                                                         int size);
-template Shrinkable<long> integral<long>(const Random &random, int size);
+                                                         size_t size);
+template Shrinkable<long> integral<long>(const Random &random, size_t size);
 template Shrinkable<unsigned long> integral<unsigned long>(const Random &random,
-                                                           int size);
+                                                           size_t size);
 template Shrinkable<long long> integral<long long>(const Random &random,
-                                                   int size);
+                                                   size_t size);
 template Shrinkable<unsigned long long>
-integral<unsigned long long>(const Random &random, int size);
+integral<unsigned long long>(const Random &random, size_t size);
 
-template Shrinkable<float> real<float>(const Random &random, int size);
-template Shrinkable<double> real<double>(const Random &random, int size);
+template Shrinkable<float> real<float>(const Random &random, size_t size);
+template Shrinkable<double> real<double>(const Random &random, size_t size);
 
-Shrinkable<bool> boolean(const Random &random, int /*size*/) {
+Shrinkable<bool> boolean(const Random &random, size_t /*size*/) {
   return shrinkable::shrinkRecur(rc::detail::bitStreamOf(random).next<bool>(),
                                  &shrink::boolean);
 }

--- a/src/gen/detail/Recipe.cpp
+++ b/src/gen/detail/Recipe.cpp
@@ -3,6 +3,8 @@
 #include "rapidcheck/seq/Transform.h"
 #include "rapidcheck/detail/Any.h"
 
+#include <stdexcept>
+
 namespace rc {
 namespace gen {
 namespace detail {
@@ -10,13 +12,18 @@ namespace detail {
 Seq<Recipe> shrinkRecipe(const Recipe &recipe) {
   using Any = rc::detail::Any;
 
+
   return seq::mapcat(
       seq::range<std::size_t>(recipe.numFixed, recipe.ingredients.size()),
       [=](std::size_t i) {
         return seq::map(recipe.ingredients[i].shrinkable.shrinks(),
                         [=](Shrinkable<Any> &&shrink) {
                           Recipe shrunkRecipe(recipe);
-                          const auto it = begin(shrunkRecipe.ingredients) + i;
+  using difference_type = decltype(begin(shrunkRecipe.ingredients))::difference_type;
+        if (i > std::numeric_limits<difference_type>::max()) {
+            throw std::overflow_error("size() greater than the iterator difference type");
+        }
+                          const auto it = begin(shrunkRecipe.ingredients) + static_cast<difference_type>(i);
                           it->shrinkable = std::move(shrink);
                           shrunkRecipe.ingredients.erase(
                               it + 1, end(shrunkRecipe.ingredients));

--- a/src/gen/detail/ScaleInteger.cpp
+++ b/src/gen/detail/ScaleInteger.cpp
@@ -46,7 +46,7 @@ uint64_t mulDiv(uint64_t a, uint32_t b, uint32_t c) {
 
 } // namespace
 
-uint64_t scaleInteger(uint64_t x, int size) {
+uint64_t scaleInteger(uint64_t x, size_t size) {
   const auto clampedSize = std::min(kNominalSize, size);
   return mulDiv(x, clampedSize, kNominalSize);
 }

--- a/src/gen/detail/ScaleInteger.cpp
+++ b/src/gen/detail/ScaleInteger.cpp
@@ -46,7 +46,7 @@ uint64_t mulDiv(uint64_t a, uint32_t b, uint32_t c) {
 
 } // namespace
 
-uint64_t scaleInteger(uint64_t x, size_t size) {
+uint64_t scaleInteger(uint64_t x, std::size_t size) {
   const auto clampedSize = std::min(kNominalSize, size);
   return mulDiv(x, clampedSize, kNominalSize);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,9 +40,10 @@ add_executable(rapidcheck_tests
   detail/SerializationTests/Misc.cpp
   detail/ShowTypeTests.cpp
   detail/StringSerializationTests.cpp
+  detail/TestingTests.cpp
   detail/TestMetadataTests.cpp
   detail/TestParamsTests.cpp
-  detail/TestingTests.cpp
+  detail/Utility.cpp
   detail/VariantTests.cpp
   fn/CommonTests.cpp
   gen/BuildTests.cpp

--- a/test/detail/Utility.cpp
+++ b/test/detail/Utility.cpp
@@ -1,0 +1,48 @@
+#include <catch2/catch.hpp>
+#include <rapidcheck/catch.h>
+
+#include "rapidcheck/detail/Utility.h"
+
+using namespace rc;
+using namespace rc::detail;
+using namespace rc::test;
+
+namespace {
+
+TEST_CASE("makeUnsigned") {
+  SECTION("in range") {
+    prop("pass through",
+         []() {
+           int i = 1;
+           size_t expected = 1;
+           RC_ASSERT(makeUnsigned(i) == expected);
+         });
+  }
+  SECTION("out of range") {
+    prop("throws SignException",
+         []() {
+           int i = -1;
+           RC_ASSERT_THROWS_AS(makeUnsigned(i), SignException);
+         });
+  }
+}
+
+TEST_CASE("makeSigned") {
+  SECTION("in range") {
+    prop("pass through",
+         []() {
+           size_t i = 1;
+           int expected = 1;
+           RC_ASSERT(makeSigned(i) == expected);
+         });
+  }
+  SECTION("out of range") {
+    prop("throws SignException",
+         []() {
+           size_t i = std::numeric_limits<size_t>::max();
+           RC_ASSERT_THROWS_AS(makeUnsigned(i), SignException);
+         });
+  }
+}
+
+}


### PR DESCRIPTION
Fix warnings/errors raised by `-Wsign-conversion`

Part 1: Convert some variables of type `int` to `size_t` when they are used for a size value that is always >= 0
Part 2: Explicitly check for values out of range when converting between signed and unsigned values and raise a new exception if they are out of range
Part 3: `static_cast` some cases when the type can be shown to be in range by inspection

Adds tests for the conversion logic