### PR TITLE
Add GTest type-parameterized fixture

### DIFF
--- a/doc/gtest.md
+++ b/doc/gtest.md
@@ -39,6 +39,20 @@ Analogous to the Google Test `TEST_F` macro, defines a RapidCheck property as a 
 
 Since this macro is implemented in terms of Google Test's `TEST` macro and Google Test does not allow mixing of `TEST` and `TEST_F` for the same test case, test cases, a property tied to a fixture named `Fixture` will be registered under a test case named `Fixed_RapidCheck`. This is usually not a big issue but is something to be aware of, in particular when filtering Google Test case names from the command line.
 
+### `RC_GTEST_TYPED_FIXTURE_PROP(Fixture, Name, (args...))`
+
+Analogous to the Google Test `TYPED_TEST` macro, defines a RapidCheck property as a Google Test typed (or type-parameterized) fixture based test. `Fixture` names the test fixture class, which must take a template parameter and is reinstantiated for every test case that is run.
+
+Similarly to `TYPED_TEST`, the type parameter can be accessed as `TypeParam` from both the argument list and the body of the property:
+```C++
+RC_GTEST_TYPED_FIXTURE_PROP(MyTypedFixture,
+                            genericSum,
+                            (TypeParam a, TypeParam b)) {
+  const TypeParam result = std::plus<TypeParam>{}(a, b);
+  RC_ASSERT(result == (a + b));
+}
+```
+
 ## Assertions
 
 RapidCheck will treat any exception as a property failure so you should be able to use any assertion mechanism that signals failures as exceptions. However, Google Test assertions are not implemented using exceptions which means that you should avoid them and use RapidCheck assertions such as `RC_ASSERT` in your RapidCheck properties instead.

--- a/examples/gtest/main.cpp
+++ b/examples/gtest/main.cpp
@@ -60,6 +60,37 @@ TEST_F(MyFixture, incrementIncrementsByOne) {
   ASSERT_EQ(1U, counter);
 }
 
+// Typed test fixtures are also supported:
+template <typename TypeParam>
+class MyTypedFixture : public ::testing::Test {
+protected:
+  void add(const TypeParam x) { sum += x; }
+
+  TypeParam sum{};
+};
+
+// A typed suite can be defined as usual ...
+using TestTypes = ::testing::Types<int, float, double>;
+TYPED_TEST_SUITE(MyTypedFixture, TestTypes, );
+
+// ... and used with properties ...
+RC_GTEST_TYPED_FIXTURE_PROP(MyTypedFixture,
+                            typeParameterizedProperty,
+                            (TypeParam a, TypeParam b)) {
+  this->add(a);
+  this->add(b);
+  RC_ASSERT(this->sum == (a + b));
+}
+
+// ...as with regular typed tests:
+TYPED_TEST(MyTypedFixture, test) {
+  const auto a = static_cast<TypeParam>(10);
+  const auto b = static_cast<TypeParam>(20);
+  this->add(a);
+  this->add(b);
+  ASSERT_EQ(this->sum, a + b);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/extras/gtest/include/rapidcheck/gtest.h
+++ b/extras/gtest/include/rapidcheck/gtest.h
@@ -60,3 +60,29 @@ void checkGTest(Testable &&testable) {
   }                                                                            \
                                                                                \
   void RapidCheckPropImpl_##Fixture##_##Name::operator() ArgList
+
+/// Defines a RapidCheck property as a typed Google Test.
+///
+/// TypedFixture is a Google Test typed (or type-parameterized) test
+/// fixture. The test type can be accessed from ArgList or from the
+/// property body as TypeParam (similarly to a TYPED_TEST).
+///
+/// The fixture is reinstantiated for each test case of the property.
+#define RC_GTEST_TYPED_FIXTURE_PROP(Fixture, Name, ArgList)                    \
+  template <typename TypeParam>                                                \
+  class RapidCheckPropImpl_##Fixture##_##Name : public Fixture<TypeParam> {    \
+  public:                                                                      \
+    void rapidCheck_fixtureSetUp() { this->SetUp(); }                          \
+    void TestBody() override {}                                                \
+    void operator() ArgList;                                                   \
+    void rapidCheck_fixtureTearDown() { this->TearDown(); }                    \
+  };                                                                           \
+                                                                               \
+  TYPED_TEST(Fixture, Name) {                                                  \
+    ::rc::detail::checkGTest(                                                  \
+        &rc::detail::ExecFixture<                                              \
+            RapidCheckPropImpl_##Fixture##_##Name<TypeParam>>::exec);          \
+  }                                                                            \
+                                                                               \
+  template <typename TypeParam>                                                \
+  void RapidCheckPropImpl_##Fixture##_##Name<TypeParam>::operator() ArgList


### PR DESCRIPTION
Hi! Would be nice to support type-parameterized properties with GoogleTest. I think this is probably the main annoyance that I face when trying to integrate RapidCheck with GoogleTest. In this PR I am implementing a macro to add such integration.

The small down-side I can think of this approach is that the test fixture will be instantiated one time too much (by the `TYPED_TEST` macro itself), but I think it should be a small overhead when the property is checked many times.

I cannot think of clean alternatives that play nice with GoogleTest, since the type list in the test suite is a private implementation detail, so a metaprogramming-based solution that manipulates the type list directly without using the `TYPED_TEST` macro sounds like a really bad idea.

Resolves #125 