### PR TITLE
Fix UB in Gtest example

### DIFF
--- a/examples/gtest/main.cpp
+++ b/examples/gtest/main.cpp
@@ -70,7 +70,7 @@ protected:
 };
 
 // A typed suite can be defined as usual ...
-using TestTypes = ::testing::Types<int, float, double>;
+using TestTypes = ::testing::Types<unsigned, float, double>;
 TYPED_TEST_SUITE(MyTypedFixture, TestTypes, );
 
 // ... and used with properties ...


### PR DESCRIPTION
Replace `int` with `unsigned` to prevent UB from signed integer overflow.