### PR TITLE
remove deprecated std::aligned_storage & std::aligned_union

### DIFF
--- a/include/rapidcheck/Maybe.h
+++ b/include/rapidcheck/Maybe.h
@@ -81,8 +81,7 @@ public:
   ~Maybe();
 
 private:
-  using Storage = typename std::aligned_storage<sizeof(T), alignof(T)>::type;
-  Storage m_storage;
+  alignas(T) uint8_t m_storage[sizeof(T)];
   bool m_initialized;
 };
 

--- a/include/rapidcheck/Maybe.hpp
+++ b/include/rapidcheck/Maybe.hpp
@@ -52,7 +52,7 @@ template <typename T>
 template <typename... Args>
 void Maybe<T>::init(Args &&... args) {
   reset();
-  new (&m_storage) T(std::forward<Args>(args)...);
+  new (m_storage) T(std::forward<Args>(args)...);
   m_initialized = true;
 }
 
@@ -66,27 +66,27 @@ void Maybe<T>::reset() {
 
 template <typename T>
 T &Maybe<T>::operator*() & {
-  return *reinterpret_cast<T *>(&m_storage);
+  return *reinterpret_cast<T *>(m_storage);
 }
 
 template <typename T>
 const T &Maybe<T>::operator*() const & {
-  return *reinterpret_cast<const T *>(&m_storage);
+  return *reinterpret_cast<const T *>(m_storage);
 }
 
 template <typename T>
 T &&Maybe<T>::operator*() && {
-  return std::move(*reinterpret_cast<T *>(&m_storage));
+  return std::move(*reinterpret_cast<T *>(m_storage));
 }
 
 template <typename T>
 T *Maybe<T>::operator->() {
-  return reinterpret_cast<T *>(&m_storage);
+  return reinterpret_cast<T *>(m_storage);
 }
 
 template <typename T>
 const T *Maybe<T>::operator->() const {
-  return reinterpret_cast<const T *>(&m_storage);
+  return reinterpret_cast<const T *>(m_storage);
 }
 
 template <typename T>

--- a/include/rapidcheck/detail/AlignedUnion.h
+++ b/include/rapidcheck/detail/AlignedUnion.h
@@ -15,11 +15,5 @@ struct MaxOf<V1, V2, Vs...>
           std::size_t,
           (V1 > MaxOf<V2, Vs...>::value ? V1 : MaxOf<V2, Vs...>::value)> {};
 
-/// Replacement for std::aligned_union for compiles that do not have it.
-template <typename... Ts>
-using AlignedUnion =
-    typename std::aligned_storage<MaxOf<sizeof(Ts)...>::value,
-                                  MaxOf<alignof(Ts)...>::value>::type;
-
 } // namespace detail
 } // namespace rc

--- a/include/rapidcheck/detail/Traits.h
+++ b/include/rapidcheck/detail/Traits.h
@@ -9,12 +9,12 @@ namespace detail {
 #define RC_SFINAE_TRAIT(Name, expression)                                      \
   struct Name##Impl {                                                          \
     template <typename T, typename = expression>                               \
-    static std::true_type test(const T &);                                     \
+    static std::true_type test(const T *);                                     \
     static std::false_type test(...);                                          \
   };                                                                           \
                                                                                \
   template <typename T>                                                        \
-  using Name = decltype(Name##Impl::test(std::declval<T>()));
+  using Name = decltype(Name##Impl::test(static_cast<T *>(nullptr)));
 
 RC_SFINAE_TRAIT(IsStreamInsertible, decltype(std::cout << std::declval<T>()))
 

--- a/include/rapidcheck/detail/Variant.h
+++ b/include/rapidcheck/detail/Variant.h
@@ -90,8 +90,8 @@ private:
   static constexpr bool isValidType();
 
   std::size_t m_typeIndex;
-  using Storage = AlignedUnion<Type, Types...>;
-  Storage m_storage;
+  alignas(MaxOf<alignof(Type), alignof(Types)...>::value)
+      uint8_t m_storage[MaxOf<sizeof(Type), sizeof(Types)...>::value];
 };
 
 template <typename Type, typename... Types>

--- a/test/detail/MulticastTestListenerTests.cpp
+++ b/test/detail/MulticastTestListenerTests.cpp
@@ -75,7 +75,7 @@ TEST_CASE("MulticastTestListener") {
     prop("passes on correct arguments",
          [](const TestMetadata &metadata, const TestResult &result) {
            MockTestListener mock;
-           mock.onTestFinishedCallback = [=](const TestMetadata &meta,
+           mock.onTestFinishedCallback = [&](const TestMetadata &meta,
                                              const TestResult &res) {
              RC_ASSERT(meta == metadata);
              RC_ASSERT(res == result);


### PR DESCRIPTION
Deprecated in C++23
See https://github.com/cplusplus/papers/issues/197