### PR TITLE
Add `-lrapidcheck` to pkg-config module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ set(PKG_CONFIG_DESCRIPTION_SUMMARY "C++ framework for property based testing ins
 set(PKG_CONFIG_VERSION)
 set(PKG_CONFIG_LIBDIR "\${prefix}/lib")
 set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include")
-set(PKG_CONFIG_LIBS)
+set(PKG_CONFIG_LIBS "-L\${libdir} -lrapidcheck")
 set(PKG_CONFIG_CFLAGS "-I\${includedir}")
 
 configure_file(


### PR DESCRIPTION
This adds the library to `rapidcheck.pc`, so that it doesn't have to be specified manually in projects that consume it.

The other modules don't need it because they have `rapidcheck` in their `Requires:` field.

I've tested this by temporarily patching the `rapidcheck` Nix package, and it behaves as expected.

With this addition, it behaves like most other libraries, and won't need any external corrections anymore.