### PR TITLE
Support for building with C++23

### DIFF
--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <exception>
 
 #include "rapidcheck/detail/Any.h"
 #include "rapidcheck/detail/ImplicitParam.h"

--- a/include/rapidcheck/Maybe.h
+++ b/include/rapidcheck/Maybe.h
@@ -81,8 +81,13 @@ public:
   ~Maybe();
 
 private:
-  using Storage = typename std::aligned_storage<sizeof(T), alignof(T)>::type;
-  Storage m_storage;
+// See https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead
+
+// using Storage = typename std::aligned_storage<sizeof(T), alignof(T)>::type;
+// Storage m_storage;
+
+  alignas(T) std::uint8_t m_storage[sizeof(T)];
+
   bool m_initialized;
 };
 

--- a/include/rapidcheck/detail/AlignedUnion.h
+++ b/include/rapidcheck/detail/AlignedUnion.h
@@ -16,10 +16,14 @@ struct MaxOf<V1, V2, Vs...>
           (V1 > MaxOf<V2, Vs...>::value ? V1 : MaxOf<V2, Vs...>::value)> {};
 
 /// Replacement for std::aligned_union for compiles that do not have it.
+///
+/// See https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead
+
 template <typename... Ts>
-using AlignedUnion =
-    typename std::aligned_storage<MaxOf<sizeof(Ts)...>::value,
-                                  MaxOf<alignof(Ts)...>::value>::type;
+struct alignas(MaxOf<alignof(Ts)...>::value) AlignedUnion
+{
+  std::uint8_t bytes [MaxOf<sizeof(Ts)...>::value];
+};
 
 } // namespace detail
 } // namespace rc


### PR DESCRIPTION
Addresses 2 issues encountered when attempting to build under C++23:

1. `Gen.hpp` is missing an inclusion of `<exception>`, which on at least one compiler (Clang 18 -std=c++23) triggers a compilation error.
2. C++23 deprecates the `std::aligned_storage` and `std::aligned_union` API's: see here [here](https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead) for a discussion of the underlying issue, as well as the suggested workarounds employed in this PR.