### PR TITLE
Give parent projects better control over cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,9 @@ if(RC_ENABLE_INSTALL)
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT ${PROJECT_NAME}
   )
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 # On Windows under MinGW, random_device provides no entropy,
@@ -124,7 +125,7 @@ add_subdirectory(extras)
 
 # Install the export file specifying all the targets for RapidCheck
 if(RC_ENABLE_INSTALL)
-  install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
+  install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake COMPONENT ${PROJECT_NAME})
   export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)
 endif()
 
@@ -144,5 +145,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD 11)
 option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)
 option(RC_ENABLE_EXAMPLES "Build RapidCheck examples" OFF)
 option(RC_ENABLE_RTTI "Build RapidCheck with RTTI" ON)
+option(RC_ENABLE_INSTALL "Install rapidcheck" ON)
 
 if(MSVC)
   # /bigobj - some object files become very large so we need this
@@ -86,13 +87,15 @@ target_include_directories(rapidcheck PUBLIC
     $<INSTALL_INTERFACE:include>  # <prefix>/include
 )
 
-include(GNUInstallDirs)
-install(TARGETS rapidcheck EXPORT rapidcheckConfig
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  include(GNUInstallDirs)
+  install(TARGETS rapidcheck EXPORT rapidcheckConfig
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 # On Windows under MinGW, random_device provides no entropy,
 # so it will always return the same value.
@@ -120,8 +123,10 @@ endif()
 add_subdirectory(extras)
 
 # Install the export file specifying all the targets for RapidCheck
-install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
-export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)
+if(RC_ENABLE_INSTALL)
+  install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
+  export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)
+endif()
 
 set(PKG_CONFIG_REQUIRES)
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "C++ framework for property based testing inspired by QuickCheck and other similar frameworks")
@@ -136,6 +141,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()

--- a/extras/boost/CMakeLists.txt
+++ b/extras/boost/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_boost INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_boost EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_boost EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 if (RC_ENABLE_TESTS)
@@ -34,5 +34,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/extras/boost/CMakeLists.txt
+++ b/extras/boost/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_boost INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_boost EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_boost EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 if (RC_ENABLE_TESTS)
   add_subdirectory(test)
@@ -29,6 +31,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()

--- a/extras/boost_test/CMakeLists.txt
+++ b/extras/boost_test/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_boost_test INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_boost_test EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_boost_test EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "boost_test headers for rapidcheck")

--- a/extras/boost_test/CMakeLists.txt
+++ b/extras/boost_test/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_boost_test INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_boost_test EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_boost_test EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
@@ -29,4 +29,5 @@ configure_file(
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  COMPONENT ${PROJECT_NAME}
   )

--- a/extras/catch/CMakeLists.txt
+++ b/extras/catch/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_catch INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_catch EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_catch EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
@@ -30,5 +30,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/extras/catch/CMakeLists.txt
+++ b/extras/catch/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_catch INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_catch EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_catch EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "catch headers for rapidcheck")
@@ -25,6 +27,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()

--- a/extras/doctest/CMakeLists.txt
+++ b/extras/doctest/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_doctest INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_doctest EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_doctest EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
@@ -30,5 +30,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/extras/doctest/CMakeLists.txt
+++ b/extras/doctest/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_doctest INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_doctest EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_doctest EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "doctest headers for rapidcheck")
@@ -25,6 +27,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()

--- a/extras/gmock/CMakeLists.txt
+++ b/extras/gmock/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_gmock INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_gmock EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_gmock EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 if (RC_ENABLE_TESTS)
@@ -34,5 +34,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/extras/gmock/CMakeLists.txt
+++ b/extras/gmock/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_gmock INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_gmock EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_gmock EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 if (RC_ENABLE_TESTS)
   add_subdirectory(test)
@@ -29,6 +31,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()

--- a/extras/gtest/CMakeLists.txt
+++ b/extras/gtest/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(rapidcheck_gtest INTERFACE
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
 if(RC_ENABLE_INSTALL)
-  install(TARGETS rapidcheck_gtest EXPORT rapidcheckConfig)
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS rapidcheck_gtest EXPORT rapidcheckConfig COMPONENT ${PROJECT_NAME})
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${PROJECT_NAME})
 endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
@@ -30,5 +30,6 @@ configure_file(
 if(RC_ENABLE_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT ${PROJECT_NAME}
     )
 endif()

--- a/extras/gtest/CMakeLists.txt
+++ b/extras/gtest/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(rapidcheck_gtest INTERFACE
 
 # An INTERFACE library does not need to install anything but its headers
 # and information on its targets.
-install(TARGETS rapidcheck_gtest EXPORT rapidcheckConfig)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(RC_ENABLE_INSTALL)
+  install(TARGETS rapidcheck_gtest EXPORT rapidcheckConfig)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 set(PKG_CONFIG_REQUIRES "rapidcheck")
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "gtest headers for rapidcheck")
@@ -25,6 +27,8 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
   )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+if(RC_ENABLE_INSTALL)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()


### PR DESCRIPTION
## Rationale

Right now rapidcheck uses cmake install functionality to install some files. This isn't always desirable, for example if someone includes rapidcheck in their project with cmakes `add_subdirectory`, this will cause rapidcheck to be installed alongside their files. Projects including rapidcheck might not want to install rapidcheck since testing is often only relevant for people working on that project, and not their consumers. Additionally, this also includes rapidcheck in packages generated with cpack.

Currently this can be worked around by re-defining `install` before including rapidcheck to a no-op and then setting it to the default value, however this is rather hacky and will break if the parent project doesn't use the standard install. ~~One can also use the `EXCLUDE_FROM_ALL` keyword argument when including rapidcheck, but this will also change when rapidcheck is built and not just installed. Furthermore, this fix doesn't adress the cpack case.~~

**Edit**: Actually I was wrong about EXCLUDE_FROM_ALL, it *does* seem to prevent it from being included in cpack case. This means that this change isn't as valuable as I first thought but I'll still leave this pull request up.

## Solution

This pull request does two things, broken up in separate commits:

 * Adds an option, `RC_ENABLE_INSTALL`. If set to on (default value), everything will be installed just as before. Setting this to off will disable all install commands (including in extras).
 * Adds an installation component which is equal to `${PROJECT_NAME}` to all install commands (so extras will have components like e.g. rapidcheck_gtest while the main gtest module will have rapidcheck). This allows users to leave install on for rapidcheck for local development but filter it from cpack with the following cmake code:
```cmake
get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
list(FILTER CPACK_COMPONENTS_ALL EXCLUDE REGEX "^rapidcheck")
```

The changes are inspired by google test: it has the `INSTALL_GTEST` cache variable which works in the same way and also sets COMPONENT to `${PROJECT_NAME}` on its installs.