### PR TITLE
[Ticket #322] Resolve compile issue of the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ add_subdirectory(ext)
 
 if(RC_ENABLE_TESTS)
   enable_testing()
+
+  add_compile_definitions(-DCATCH_CONFIG_NO_POSIX_SIGNALS)
+
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
MINSIGSTKSZ was remove in one of the system lib causing compile error of the tests.