### PR TITLE
Fix GTest SetUpTestSuite bug

### DIFF
--- a/examples/gtest/main.cpp
+++ b/examples/gtest/main.cpp
@@ -33,14 +33,27 @@ protected:
     // SetUp works as usual...
   }
 
-  void increment() { counter++; }
+  static void SetUpTestSuite() {
+    // ... SetUpTestSuite also works
+    step_size = 1U;
+  }
+
+  void increment() { counter += step_size; }
 
   void TearDown() override {
     // ...as does TearDown
   }
 
+  static void TearDownTestSuite() {
+    // ... and TearDownTestSuite
+    EXPECT_EQ(step_size, 1U);
+  }
+
   std::size_t counter;
+  static std::size_t step_size;
 };
+
+std::size_t MyFixture::step_size{0U};
 
 // ...and use them like this:
 RC_GTEST_FIXTURE_PROP(MyFixture,

--- a/extras/gtest/include/rapidcheck/gtest.h
+++ b/extras/gtest/include/rapidcheck/gtest.h
@@ -54,7 +54,7 @@ void checkGTest(Testable &&testable) {
     void rapidCheck_fixtureTearDown() { TearDown(); }                          \
   };                                                                           \
                                                                                \
-  TEST(Fixture##_RapidCheck, Name) {                                           \
+  TEST_F(Fixture, RapidCheck_##Name) {                                         \
     ::rc::detail::checkGTest(&rc::detail::ExecFixture<                         \
                              RapidCheckPropImpl_##Fixture##_##Name>::exec);    \
   }                                                                            \


### PR DESCRIPTION
Since RC_GTEST_FIXTURE_PROP is not registering the properties as GTest test cases within the given fixture, if the given fixture defines SetUpTestSuite or TearDownTestSuite they will not be called by RapidCheck, and there is no guarantee that they have already been called by GTest. This will result in bugs.

Fix this issue by ensuring that the properties are registered as test cases in the given GTest fixture.

This slightly alters the naming scheme for GTest test cases generated by RC_GTEST_FIXTURE_PROP.

Resolves #338