### PR TITLE
Fix cmake/pkgconfig install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,13 +124,7 @@ add_subdirectory(extras)
 install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
 export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)
 
-set(PKG_CONFIG_REQUIRES)
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "C++ framework for property based testing inspired by QuickCheck and other similar frameworks")
-set(PKG_CONFIG_VERSION)
-set(PKG_CONFIG_LIBDIR "\${prefix}/lib")
-set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include")
-set(PKG_CONFIG_LIBS)
-set(PKG_CONFIG_CFLAGS "-I\${includedir}")
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(RC_ENABLE_TESTS "Build RapidCheck tests" OFF)
 option(RC_ENABLE_EXAMPLES "Build RapidCheck examples" OFF)
 option(RC_ENABLE_RTTI "Build RapidCheck with RTTI" ON)
 
+include(GNUInstallDirs)
+
 if(MSVC)
   # /bigobj - some object files become very large so we need this
   # /wd4503 - truncation of decorated name, not much we can do about it so
@@ -83,10 +85,9 @@ endif()
 
 target_include_directories(rapidcheck PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-    $<INSTALL_INTERFACE:include>  # <prefix>/include
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-include(GNUInstallDirs)
 install(TARGETS rapidcheck EXPORT rapidcheckConfig
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 add_subdirectory(extras)
 
 # Install the export file specifying all the targets for RapidCheck
-install(EXPORT rapidcheckConfig DESTINATION share/rapidcheck/cmake)
+install(EXPORT rapidcheckConfig DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 export(EXPORT rapidcheckConfig FILE rapidcheckConfig.cmake)
 
 set(PKG_CONFIG_DESCRIPTION_SUMMARY "C++ framework for property based testing inspired by QuickCheck and other similar frameworks")

--- a/pkg-config.pc.cmake
+++ b/pkg-config.pc.cmake
@@ -1,9 +1,9 @@
+prefix=${CMAKE_INSTALL_PREFIX}
+includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}
+libdir=${CMAKE_INSTALL_FULL_LIBDIR}
+
 Name: ${PROJECT_NAME}
 Description: ${PKG_CONFIG_DESCRIPTION_SUMMARY}
-Version: ${PKG_CONFIG_VERSION}
-Requires: ${PKG_CONFIG_REQUIRES}
-prefix=${CMAKE_INSTALL_PREFIX}
-includedir=${PKG_CONFIG_INCLUDEDIR}
-libdir=${PKG_CONFIG_LIBDIR}
-Libs: ${PKG_CONFIG_LIBS}
-Cflags: ${PKG_CONFIG_CFLAGS}
+Version: 
+Libs: -L${libdir} -lrapidcheck
+Cflags: -I${includedir}


### PR DESCRIPTION
Fix and clean up the CMake config and the generated `.pc` file. This is necessary, in particular, in situations when the `.so` library and the headers are installed into different prefix directories.