### PR TITLE
[c++26 fix] include <exception> in Gen.hpp

### DIFF
--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <exception>
 
 #include "rapidcheck/detail/Any.h"
 #include "rapidcheck/detail/ImplicitParam.h"


### PR DESCRIPTION
When compiling in a c++26 project, I get this error:

```
  rapidcheck/Gen.hpp:72:22: error: calling 'current_exception' with incomplete return type 'exception_ptr'
     72 |     auto exception = std::current_exception();
        |                      ^~~~~~~~~~~~~~~~~~~~~~~~
  .../exception/operations.h:36:33: note: forward declaration of 'std::exception_ptr'
     36 | class _LIBCPP_EXPORTED_FROM_ABI exception_ptr;
        |                                 ^
```

Including \<exception\> fixes it, and this seems correct to me because https://en.cppreference.com/w/cpp/error/exception_ptr.html says that it's defined in \<exception\>.