### PR TITLE
Add missing <exception> include in Gen.hpp

### DIFF
--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <exception>
 
 #include "rapidcheck/detail/Any.h"
 #include "rapidcheck/detail/ImplicitParam.h"


### PR DESCRIPTION
`Gen.hpp` uses `std::current_exception()` and `std::rethrow_exception()` but does not include `<exception>`. With libc++ (clang/LLVM 21), `exception_ptr` is only forward-declared in the headers pulled in transitively, causing a build error:

```
error: calling 'current_exception' with incomplete return type 'exception_ptr'
    auto exception = std::current_exception();
                     ^~~~~~~~~~~~~~~~~~~~~~~~
```

Fix: add #include <exception> alongside the existing `#include <cassert>`.
