### PR TITLE
Upstream float support for `inRange`

### DIFF
--- a/include/rapidcheck/gen/Numeric.h
+++ b/include/rapidcheck/gen/Numeric.h
@@ -5,7 +5,7 @@
 namespace rc {
 namespace gen {
 
-/// Generates an integer in a given range.
+/// Generates an integer or floating point value in a given range.
 ///
 /// @param min  The minimum value, inclusive.
 /// @param max  The maximum value, exclusive.

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -6,6 +6,8 @@
 #include "rapidcheck/gen/Transform.h"
 #include "rapidcheck/gen/detail/ScaleInteger.h"
 
+#include <cmath>
+
 namespace rc {
 namespace gen {
 namespace detail {
@@ -85,22 +87,25 @@ struct DefaultArbitrary<bool> {
   static Gen<bool> arbitrary() { return boolean; }
 };
 
-} // namespace detail
+template <typename T>
+void assertValidRange(T min, T max) {
+  if (max <= min) {
+    std::string msg;
+    msg += "Invalid range [" + std::to_string(min);
+    msg += ", " + std::to_string(max) + ")";
+    throw GenerationFailure(msg);
+  }
+}
 
 template <typename T>
-Gen<T> inRange(T min, T max) {
+Gen<T> inRange(T min, T max, std::false_type) {
   return [=](const Random &random, int size) {
-    if (max <= min) {
-      std::string msg;
-      msg += "Invalid range [" + std::to_string(min);
-      msg += ", " + std::to_string(max) + ")";
-      throw GenerationFailure(msg);
-    }
+    assertValidRange(min, max);
 
     const auto rangeSize =
-        detail::scaleInteger(static_cast<Random::Number>(max) -
-                                 static_cast<Random::Number>(min) - 1,
-                             size) +
+        scaleInteger(static_cast<Random::Number>(max) -
+                         static_cast<Random::Number>(min) - 1,
+                     size) +
         1;
     const auto value =
         static_cast<T>((Random(random).next() % rangeSize) + min);
@@ -108,6 +113,38 @@ Gen<T> inRange(T min, T max) {
     return shrinkable::shrinkRecur(
         value, [=](T x) { return shrink::towards<T>(x, min); });
   };
+}
+
+template <typename T>
+Gen<T> inRange(T min, T max, std::true_type) {
+  return [=](const Random &random, int size) {
+    assertValidRange(min, max);
+
+    const auto unit =
+        static_cast<T>(Random(random).next()) /
+        (static_cast<T>(std::numeric_limits<Random::Number>::max()) + 1);
+    // As for integrals, `size` decides how much of the range is used, with a
+    // size of zero yielding only `min`.
+    const auto scale =
+        std::min(size, kNominalSize) / static_cast<T>(kNominalSize);
+
+    auto value = min + ((max - min) * unit * scale);
+    // Rounding can land on `max`, which is exclusive.
+    if (value >= max) {
+      value = std::nextafter(max, min);
+    }
+
+    assert(value >= min && value < max);
+    return shrinkable::shrinkRecur(
+        value, [=](T x) { return shrink::towards<T>(x, min); });
+  };
+}
+
+} // namespace detail
+
+template <typename T>
+Gen<T> inRange(T min, T max) {
+  return detail::inRange<T>(min, max, std::is_floating_point<T>());
 }
 
 } // namespace gen

--- a/include/rapidcheck/gen/Numeric.hpp
+++ b/include/rapidcheck/gen/Numeric.hpp
@@ -116,9 +116,20 @@ Gen<T> inRange(T min, T max, std::false_type) {
 }
 
 template <typename T>
+void assertFiniteRange(T min, T max) {
+  if (!std::isfinite(min) || !std::isfinite(max)) {
+    std::string msg;
+    msg += "Non-finite range [" + std::to_string(min);
+    msg += ", " + std::to_string(max) + ")";
+    throw GenerationFailure(msg);
+  }
+}
+
+template <typename T>
 Gen<T> inRange(T min, T max, std::true_type) {
   return [=](const Random &random, int size) {
     assertValidRange(min, max);
+    assertFiniteRange(min, max);
 
     const auto unit =
         static_cast<T>(Random(random).next()) /
@@ -128,8 +139,9 @@ Gen<T> inRange(T min, T max, std::true_type) {
     const auto scale =
         std::min(size, kNominalSize) / static_cast<T>(kNominalSize);
 
-    auto value = min + ((max - min) * unit * scale);
-    // Rounding can land on `max`, which is exclusive.
+    // Interpolate the value and limit it to the range [min, max)
+    const auto t = unit * scale;
+    auto value = ((1 - t) * min) + (t * max);
     if (value >= max) {
       value = std::nextafter(max, min);
     }

--- a/include/rapidcheck/shrink/Shrink.h
+++ b/include/rapidcheck/shrink/Shrink.h
@@ -28,10 +28,11 @@ Seq<Container> removeChunks(Container elements);
 template <typename Container, typename Shrink>
 Seq<Container> eachElement(Container elements, Shrink shrink);
 
-/// Shrinks an integral value towards another integral value.
+/// Shrinks an integral or floating point value towards another value of the
+/// same type by repeated bisection. The target is always tried first.
 ///
 /// @param value   The value to shrink.
-/// @param target  The integer to shrink towards.
+/// @param target  The value to shrink towards.
 template <typename T>
 Seq<T> towards(T value, T target);
 

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -48,13 +48,13 @@ public:
       , m_target(target) {}
 
   Maybe<T> operator()() {
-    if (m_value == m_target) {
+    if (m_value == m_target || std::isnan(m_value) || std::isnan(m_target)) {
       return Nothing;
     }
 
     T new_value = (m_value / 2) + (m_target / 2);
 
-    if (new_value == m_value) {
+    if (new_value == m_value || std::isnan(new_value)) {
       new_value = m_target;
     }
 

--- a/include/rapidcheck/shrink/Shrink.hpp
+++ b/include/rapidcheck/shrink/Shrink.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <locale>
 
@@ -11,7 +12,7 @@ namespace rc {
 namespace shrink {
 namespace detail {
 
-template <typename T>
+template <typename T, typename Enable = void>
 class TowardsSeq {
 public:
   using UInt = typename std::make_unsigned<T>::type;
@@ -35,6 +36,35 @@ private:
   T m_value;
   UInt m_diff;
   bool m_down;
+};
+
+template <typename T>
+class TowardsSeq<
+    T,
+    typename std::enable_if<std::is_floating_point<T>::value>::type> {
+public:
+  TowardsSeq(T value, T target)
+      : m_value(value)
+      , m_target(target) {}
+
+  Maybe<T> operator()() {
+    if (m_value == m_target) {
+      return Nothing;
+    }
+
+    T new_value = (m_value / 2) + (m_target / 2);
+
+    if (new_value == m_value) {
+      new_value = m_target;
+    }
+
+    m_value = new_value;
+    return m_value;
+  }
+
+private:
+  T m_value;
+  T m_target;
 };
 
 template <typename Container>

--- a/test/gen/NumericTests.cpp
+++ b/test/gen/NumericTests.cpp
@@ -174,16 +174,21 @@ TEST_CASE("arbitrary reals") {
 
 namespace {
 
+template <typename T>
+Gen<std::pair<T, T>> genRangeOf() {
+  // TODO proper range generator
+  return gen::exec([] {
+    const auto a = *gen::arbitrary<T>();
+    const auto b = *gen::distinctFrom(a);
+    return std::make_pair(std::min(a, b), std::max(a, b));
+  });
+}
+
 struct InRangeProperties {
   template <typename T>
   static void exec() {
 
-    // TODO proper range generator
-    static const auto genRange = gen::exec([] {
-      const auto a = *gen::arbitrary<T>();
-      const auto b = *gen::distinctFrom(a);
-      return std::make_pair(std::min(a, b), std::max(a, b));
-    });
+    static const auto genRange = genRangeOf<T>();
 
     templatedProp<T>(
         "never generates values outside of range",
@@ -210,6 +215,22 @@ struct InRangeProperties {
                        RC_ASSERT_THROWS_AS(shrinkable.value(),
                                            GenerationFailure);
                      });
+
+    templatedProp<T>("when size == 0, generates only min",
+                     [](const Random &random) {
+                       const auto range = *genRange;
+                       RC_ASSERT(
+                           gen::inRange(range.first, range.second)(random, 0) ==
+                           shrinkable::just(range.first));
+                     });
+  }
+};
+
+struct InRangeIntegralProperties {
+  template <typename T>
+  static void exec() {
+
+    static const auto genRange = genRangeOf<T>();
 
     templatedProp<T>("first shrink is min",
                      [](const GenParams &params) {
@@ -249,14 +270,6 @@ struct InRangeProperties {
           RC_FAIL("Gave up");
         });
 
-    templatedProp<T>("when size == 0, generates only min",
-                     [](const Random &random) {
-                       const auto range = *genRange;
-                       RC_ASSERT(
-                           gen::inRange(range.first, range.second)(random, 0) ==
-                           shrinkable::just(range.first));
-                     });
-
     templatedProp<T>("finds shrink where value must be larger than some value",
                      [](const Random &random) {
                        const auto range = *genRange;
@@ -273,8 +286,54 @@ struct InRangeProperties {
   }
 };
 
+struct InRangeRealProperties {
+  template <typename T>
+  static void exec() {
+
+    static const auto genRange = genRangeOf<T>();
+
+    templatedProp<T>(
+        "spreads values over the whole range",
+        [](const Random &random) {
+          // Unlike the integral case a continuous range cannot be covered
+          // exhaustively, so check that every decile gets hit instead.
+          const auto min = *gen::inRange<T>(-1000, 1000);
+          const auto max = min + *gen::inRange<T>(1, 1000);
+
+          const auto gen = gen::inRange<T>(min, max);
+          auto r = random;
+          std::vector<int> counts(10, 0);
+          for (std::size_t i = 0; i < 100000; i++) {
+            const auto x = gen(r.split(), kNominalSize).value();
+            const auto decile = static_cast<std::size_t>(
+                (10 * (x - min)) / (max - min));
+            counts[std::min<std::size_t>(decile, 9)]++;
+            if (std::find(begin(counts), end(counts), 0) == end(counts)) {
+              RC_SUCCEED("All deciles generated");
+            }
+          }
+
+          RC_FAIL("Gave up");
+        });
+
+    templatedProp<T>(
+        "shrinks towards min",
+        [](const GenParams &params) {
+          const auto range = *genRange;
+          const auto shrinkable =
+              gen::inRange<T>(range.first, range.second)(params.random,
+                                                         params.size);
+          const auto result = shrinkable::findLocalMin(
+              shrinkable, [](T) { return true; });
+          RC_ASSERT(result.first == range.first);
+        });
+  }
+};
+
 } // namespace
 
 TEST_CASE("gen::inRange") {
-  forEachType<InRangeProperties, RC_INTEGRAL_TYPES>();
+  forEachType<InRangeProperties, RC_NUMERIC_TYPES>();
+  forEachType<InRangeIntegralProperties, RC_INTEGRAL_TYPES>();
+  forEachType<InRangeRealProperties, RC_REAL_TYPES>();
 }

--- a/test/shrink/ShrinkTests.cpp
+++ b/test/shrink/ShrinkTests.cpp
@@ -123,6 +123,28 @@ namespace {
 struct ShrinkTowardsProperties {
   template <typename T>
   static void exec() {
+    templatedProp<T>(
+        "shrinking towards self yields empty shrink",
+        [](T target) { RC_ASSERT(!shrink::towards(target, target).next()); });
+
+    templatedProp<T>(
+        "never contains original value",
+        [](T x, T y) { RC_ASSERT(!seq::contains(shrink::towards(x, y), x)); });
+
+    templatedProp<T>("never leaves the interval between target and value",
+                     [](T target) {
+                       T value = *gen::distinctFrom(target);
+                       const auto lo = std::min(value, target);
+                       const auto hi = std::max(value, target);
+                       seq::forEach(shrink::towards(value, target),
+                                    [=](T x) { RC_ASSERT(x >= lo && x <= hi); });
+                     });
+  }
+};
+
+struct ShrinkTowardsIntegralProperties {
+  template <typename T>
+  static void exec() {
     templatedProp<T>("first tries target immediately",
                      [](T target) {
                        T value = *gen::distinctFrom(target);
@@ -142,21 +164,40 @@ struct ShrinkTowardsProperties {
                            (value > target) ? (value - *fin) : (*fin - value);
                        RC_ASSERT(diff == T(1));
                      });
+  }
+};
 
-    templatedProp<T>(
-        "shrinking towards self yields empty shrink",
-        [](T target) { RC_ASSERT(!shrink::towards(target, target).next()); });
+struct ShrinkTowardsRealProperties {
+  template <typename T>
+  static void exec() {
+    templatedProp<T>("each shrink is closer to the target than the last",
+                     [](T target) {
+                       T value = *gen::distinctFrom(target);
+                       T previous = value;
+                       seq::forEach(shrink::towards(value, target),
+                                    [&](T x) {
+                                      RC_ASSERT(std::abs(x - target) <
+                                                std::abs(previous - target));
+                                      previous = x;
+                                    });
+                     });
 
-    templatedProp<T>(
-        "never contains original value",
-        [](T x, T y) { RC_ASSERT(!seq::contains(shrink::towards(x, y), x)); });
+    templatedProp<T>("reaches the target",
+                     [](T target) {
+                       T value = *gen::distinctFrom(target);
+                       const auto fin = seq::last(shrink::towards(value, target));
+                       RC_ASSERT(fin);
+                       RC_ASSERT(*fin == target);
+                     });
   }
 };
 
 } // namespace
 
 TEST_CASE("shrink::towards") {
-  forEachType<ShrinkTowardsProperties, RC_INTEGRAL_TYPES>();
+  forEachType<ShrinkTowardsProperties, RC_NUMERIC_TYPES>();
+  forEachType<ShrinkTowardsIntegralProperties, RC_INTEGRAL_TYPES>();
+  forEachType<ShrinkTowardsRealProperties, RC_REAL_TYPES>();
 }
 
 namespace {


### PR DESCRIPTION
Upstreaming our patches for float support:
- Split `inRange` into an overloaded function for floating values in `Numeric.hpp`. Floating values cannot use an integer modulo.
- Add `float` specialization to `TowardsSeq` in `Shrink.hpp`. The integral version of `TowardsSeq` uses `std::make_unsigned`, which is unavailable for floating values.
- Add tests

I tested with gcc-11 (therefore I had to temporarily update `ext/catch` to `v2.13.10`)